### PR TITLE
add a file for common links

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,6 +31,10 @@ extensions = [
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.sphinx']
 
+rst_epilog = """
+.. include:: /reuse/links.txt
+"""
+
 # Links to ignore when checking links
 
 linkcheck_ignore = [

--- a/reuse/links.txt
+++ b/reuse/links.txt
@@ -1,0 +1,1 @@
+.. _Canonical website: https://canonical.com/


### PR DESCRIPTION
All links defined in the reuse/links.txt file are available in all documentation pages in the project.