### PR TITLE
allow adjusting the table alignment

### DIFF
--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -26,9 +26,9 @@ table.docutils td, table.docutils th, table.docutils td:last-child, table.docuti
     border-left: none;
 }
 
-/* Centre text horizontally in table data cells */
-table.docutils td {
-    text-align: center;
+/* Allow to centre text horizontally in table data cells */
+table.align-center {
+    text-align: center !important;
 }
 
 /** No rounded corners **/

--- a/doc-cheat-sheet.rst
+++ b/doc-cheat-sheet.rst
@@ -128,6 +128,31 @@ Tables
    * - Cell 3
      - Cell 4
 
+.. rst-class:: align-center
+
+   +----------------------+------------+
+   | Header 1             | Header 2   |
+   +======================+============+
+   | Cell 1               | Cell 2     |
+   |                      |            |
+   | Second paragraph     |            |
+   +----------------------+------------+
+   | Cell 3               | Cell 4     |
+   +----------------------+------------+
+
+.. list-table::
+   :header-rows: 1
+   :align: center
+
+   * - Header 1
+     - Header 2
+   * - Cell 1
+
+       Second paragraph
+     - Cell 2
+   * - Cell 3
+     - Cell 4
+
 Notes
 -----
 


### PR DESCRIPTION
Forcing the alignment in table cells to always center can lead to undesired output.
For example:
![image](https://user-images.githubusercontent.com/11227796/233673728-4635f720-f0d9-4bc7-9ea8-c326a5fc6907.png)

Instead, leave the default at left-aligned, but allow to center-align using reST syntax (examples added to the cheat sheet).