### PR TITLE
Provide default RTD configuration by adding a readthedocs.yaml file.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: conf.py
+
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: .sphinx/requirements.txt


### PR DESCRIPTION
Currently it is a minimal file, needed to avoid a recent RTD build error (https://github.com/readthedocs/readthedocs.org/issues/10290).