### PR TITLE
add default configuration to readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,8 +13,13 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: conf.py
+  builder: dirhtml
+  configuration: conf.py
+  fail_on_warning: true
 
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Update the configuration file with the default configuration - mainly the builder (dirhtml) and the formats we want to generate (only PDF in addition to HTML).

Closes #26.