### PR TITLE
explicitly add the working directory to the GitHub action

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -21,10 +21,12 @@ jobs:
           sudo apt-get install aspell aspell-en
 
       - name: Install the doc framework
+        working-directory: .
         run: |
           make install
 
       - name: Build docs and run spelling checker
+        working-directory: .
         run: |
           make spelling
 
@@ -40,6 +42,7 @@ jobs:
         with:
           # Cause the check to fail on any broke rules
           fail-on-error: true
+          workdir: .
           woke-args: "*.rst **/*.rst -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml"
 
   linkcheck:
@@ -50,9 +53,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install the doc framework
+        working-directory: .
         run: |
           make install
 
       - name: Run linkchecker
+        working-directory: .
         run: |
           make linkcheck

--- a/readme.rst
+++ b/readme.rst
@@ -28,6 +28,7 @@ Copy all the files and folders (with the exception of the ``.git`` folder) from 
 Then do the following changes:
 
 - Move the workflow files from the ``docs/.github`` folder into the ``.github`` folder of the root directory of your code repository, or include the job logic from the files into your existing workflows.
+  Make sure to adapt the working directory for each job by changing the path in the ``working-directory`` or ``workdir`` field.
 - Optionally, integrate the targets from the ``docs/Makefile`` file into the Makefile for your code repository.
   Alternatively, you can run the ``make`` commands for documentation inside the ``docs`` folder.
 - Optionally, move the ``docs/.readthedocs.yaml`` file into the root directory of your repository and adapt the paths for ``sphinx.configuration`` and ``python.install.requirements``.


### PR DESCRIPTION
That makes it easier to adapt the jobs if the docs are in a different directory.