### PR TITLE
Fix and improve links

### DIFF
--- a/reuse/links.txt
+++ b/reuse/links.txt
@@ -1,7 +1,7 @@
 .. _Canonical website: https://canonical.com/
 .. _reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
-.. _Sphinx reStructuredText Primer: https://tinyurl.com/rstprimer
+.. _Sphinx reStructuredText Primer: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _Canonical Documentation Style Guide: https://docs.ubuntu.com/styleguide/en
-.. _Read the Docs at Canonical: https://library.canonical.com/40-documentation/read-the-docs
-.. _How to publish documentation on Read the Docs: https://library.canonical.com/40-documentation/publish-on-read-the-docs
+.. _Read the Docs at Canonical: https://library.canonical.com/documentation/read-the-docs
+.. _How to publish documentation on Read the Docs: https://library.canonical.com/documentation/publish-on-read-the-docs
 .. _Example product documentation: https://canonical-example-product-documentation.readthedocs-hosted.com/


### PR DESCRIPTION
This PR fixes two links that were pointing to library.canonical.com . The `linkcheck` make job may not able to detect broken links to that domain due to 2FA.

There was also a link that used a URL shortener which is not best practice.