### PR TITLE
add a default for ogp_image to prevent a font bug

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,11 @@ myst_enable_extensions = [
 if 'discourse' in html_context:
     html_context['discourse_prefix'] = html_context['discourse'] + '/t/'
 
+# Default image for OGP (to prevent font errors, see
+# https://github.com/canonical/sphinx-docs-starter-pack/pull/54 )
+if not 'ogp_image' in locals():
+    ogp_image = 'https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg'
+
 ############################################################
 ### General configuration
 ############################################################


### PR DESCRIPTION
Make sure we don't get a font error if someone comments out ogp_image. See https://github.com/wpilibsuite/sphinxext-opengraph/issues/107

Fixes #42.