### PR TITLE
fix path to the tag in the header

### DIFF
--- a/.sphinx/_templates/header.html
+++ b/.sphinx/_templates/header.html
@@ -6,7 +6,7 @@
 
       <li>
         <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
-          <img src="{{ product_tag }}" alt="Logo" class="p-logo-image">
+          <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
           <div class="p-logo-text p-heading--4">{{ project }}
           </div>
         </a>

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -43,8 +43,8 @@ html_context = {
     'product_page': 'documentation.ubuntu.com',
 
     # Add your product tag to ".sphinx/_static" and change the path
-    # here (start with "/static"), default is the circle of friends
-    'product_tag': '/_static/tag.png',
+    # here (start with "_static"), default is the circle of friends
+    'product_tag': '_static/tag.png',
 
     # Change to the discourse instance you want to be able to link to
     # using the :discourse: metadata at the top of a file


### PR DESCRIPTION
If RTD is configured for multiple versions, it adds an automatic redirect to /en/latest, which messes up linking to anything at root level.