### PR TITLE
feat: refactor woke for SSoT

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -37,13 +37,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: woke
-        uses: get-woke/woke-action@v0
-        with:
-          # Cause the check to fail on any broke rules
-          fail-on-error: true
-          workdir: .
-          woke-args: "*.rst **/*.rst -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml"
+      - name: Install the doc framework
+        working-directory: .
+        run: |
+          make install
+
+      - name: Run incluse-language checker
+        working-directory: .
+        run: |
+          make woke
 
   linkcheck:
     name: Link check

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ linkcheck:
 	. $(VENV) ; $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"
 
 woke:
-	type woke >/dev/null 2>&1 || { snap install woke; exit 1; }
+	type woke >/dev/null 2>&1 || { sudo snap install woke; }
 	woke *.rst **/*.rst -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml
 
 .PHONY: help Makefile


### PR DESCRIPTION
- Replace woke command in GitHub action with call to existing make woke
- Makefile needs sudo to install Snap if woke missing
- Missing-woke problem solved by sudo snap install; no need for error exit
- [Jira](https://warthogs.atlassian.net/browse/DOCPR-55)