### PR TITLE
Makefile: refactor 'woke', wrap longer lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,24 +27,23 @@ $(VENVDIR): $(SPHINXDIR)/requirements.txt
 	@echo "... setting up virtualenv"
 	python3 -m venv $(VENVDIR)
 	. $(VENV); pip install --upgrade -r $(SPHINXDIR)/requirements.txt
-
 	@echo "\n" \
-		"--------------------------------------------------------------- \n" \
-		"* watch, build and serve the documentation: make run \n" \
-                "* only build: make html \n" \
-                "* only serve: make serve \n" \
-                "* clean built doc files: make clean-doc \n" \
-                "* clean full environment: make clean \n" \
-                "* check spelling: make spelling \n" \
-                "* check inclusive language: make woke \n" \
-                "* other possible targets: make <press TAB twice> \n" \
-		"--------------------------------------------------------------- \n"
+        "--------------------------------------------------------------- \n" \
+        "* watch, build and serve the documentation: make run \n" \
+        "* only build: make html \n" \
+        "* only serve: make serve \n" \
+        "* clean built doc files: make clean-doc \n" \
+        "* clean full environment: make clean \n" \
+        "* check spelling: make spelling \n" \
+        "* check inclusive language: make woke \n" \
+        "* other possible targets: make <press TAB twice> \n" \
+        "--------------------------------------------------------------- \n"
 	@touch $(VENVDIR)
 
 
 woke-install:
 	@type woke >/dev/null 2>&1 || \
-		{ echo "Installing \"woke\" needs sudo \n"; sudo snap install woke; }
+        { echo "Installing \"woke\" snap... \n"; sudo snap install woke; }
 
 .PHONY:  woke-install
 
@@ -61,13 +60,15 @@ run: install
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 html: install
-	. $(VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w .sphinx/warnings.txt
+	. $(VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" \
+        -w .sphinx/warnings.txt
 
 .PHONY: html
 
 
 epub: install
-	. $(VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w .sphinx/warnings.txt
+	. $(VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)" \
+        -w .sphinx/warnings.txt
 
 .PHONY: epub
 
@@ -79,7 +80,8 @@ serve: html
 
 
 clean: clean-doc
-	@test ! -e "$(VENVDIR)" -o -d "$(VENVDIR)" -a "$(abspath $(VENVDIR))" != "$(VENVDIR)"
+	@test ! -e "$(VENVDIR)" -o \
+        -d "$(VENVDIR)" -a "$(abspath $(VENVDIR))" != "$(VENVDIR)"
 	rm -rf $(VENVDIR)
 
 .PHONY: clean
@@ -104,7 +106,8 @@ linkcheck: install
 
 
 woke: woke-install
-	woke *.rst **/*.rst -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
+	woke *.rst **/*.rst \
+        -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
 .PHONY: woke
 
@@ -112,6 +115,7 @@ woke: woke-install
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	. $(VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	. $(VENV); \
+        $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: Makefile


### PR DESCRIPTION
This aims to extract the installation logic of the 'make woke' target into other targets while making the process more explicit for the user with echo commands.

Some of the longer recipe lines affected by this could benefit from wrapping, so a related change is added as a follow-up.