### PR TITLE
allow customising linkcheck_anchors_ignore_for_url

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -89,6 +89,7 @@ if not 'conf_py_path' in html_context and 'github_folder' in html_context:
 linkcheck_anchors_ignore_for_url = [
     r'https://github\.com/.*'
 ]
+linkcheck_anchors_ignore_for_url.extend(custom_linkcheck_anchors_ignore_for_url)
 
 ############################################################
 ### Styling

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -102,6 +102,12 @@ linkcheck_ignore = [
     'http://127.0.0.1:8000'
     ]
 
+# Pages on which to ignore anchors
+# (This list will be appended to linkcheck_anchors_ignore_for_url)
+
+custom_linkcheck_anchors_ignore_for_url = [
+    ]
+
 ############################################################
 ### Additions to default configuration
 ############################################################


### PR DESCRIPTION
Users might want to add more URLs for which the anchors are ignored, so add a custom variable for this.
We should ignore GitHub globally, since those anchors are handled in a way the linkchecker can't deal with, so this will be an issue for all doc sets.