### PR TITLE
add 'make install' logging, harden venv installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ $(SPHINXDIR)/requirements.txt:
 $(VENVDIR): $(SPHINXDIR)/requirements.txt
 	@echo "... setting up virtualenv"
 	python3 -m venv $(VENVDIR)
-	. $(VENV); pip install --upgrade -r $(SPHINXDIR)/requirements.txt \
+	. $(VENV); pip install --require-virtualenv \
+        --upgrade -r $(SPHINXDIR)/requirements.txt \
         --log $(VENVDIR)/pip_install.log
 	@test ! -f $(VENVDIR)/pip_list.txt || \
         mv $(VENVDIR)/pip_list.txt $(VENVDIR)/pip_list.txt.bak


### PR DESCRIPTION
This adds two logs to the 'install' target; namely, `pip`'s own installation log (really verbose) and a `pip list` dump in `freeze` form that is preserved to simplify rollback. The `make clean` command deletes all these logs and backups.

Also, this hardens the 'install' target via the use of `--require-virtualenv` [1]

This closes issue #90.

Links:
1. <https://pip.pypa.io/en/stable/cli/pip/#cmdoption-require-virtualenv>