### PR TITLE
Optional nav

### DIFF
--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -1,31 +1,33 @@
 {# ru-fu: copied from Furo, with modifications as stated below #}
 
 <div class="related-pages">
-  {% if next -%}
-    <a class="next-page" href="{{ next.link }}">
-      <div class="page-info">
-        <div class="context">
-          <span>{{ _("Next") }}</span>
+  {% if sequential_nav != "none" -%}
+    {% if next and (sequential_nav == "next" or sequential_nav == "both") -%}
+      <a class="next-page" href="{{ next.link }}">
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Next") }}</span>
+          </div>
+          <div class="title">{{ next.title }}</div>
         </div>
-        <div class="title">{{ next.title }}</div>
-      </div>
-      <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
-    </a>
-  {%- endif %}
-  {% if prev -%}
-    <a class="prev-page" href="{{ prev.link }}">
-      <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
-      <div class="page-info">
-        <div class="context">
-          <span>{{ _("Previous") }}</span>
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+      </a>
+    {%- endif %}
+    {% if prev and (sequential_nav == "prev" or sequential_nav == "both") -%}
+      <a class="prev-page" href="{{ prev.link }}">
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Previous") }}</span>
+          </div>
+          {% if prev.link == pathto(master_doc) %}
+            <div class="title">{{ _("Home") }}</div>
+          {% else %}
+            <div class="title">{{ prev.title }}</div>
+          {% endif %}
         </div>
-        {% if prev.link == pathto(master_doc) %}
-        <div class="title">{{ _("Home") }}</div>
-        {% else %}
-        <div class="title">{{ prev.title }}</div>
-        {% endif %}
-      </div>
-    </a>
+      </a>
+    {%- endif %}
   {%- endif %}
 </div>
 <div class="bottom-of-page">

--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -1,6 +1,11 @@
 {# ru-fu: copied from Furo, with modifications as stated below #}
 
 <div class="related-pages">
+  {% if meta %}
+    {% if 'sequential_nav' in meta %}
+      {% set sequential_nav = meta.sequential_nav %}
+    {% endif %}  
+  {% endif %}
   {% if sequential_nav != "none" -%}
     {% if next and (sequential_nav == "next" or sequential_nav == "both") -%}
       <a class="next-page" href="{{ next.link }}">

--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -1,11 +1,13 @@
-{# ru-fu: copied from Furo, with modifications as stated below #}
+{# ru-fu: copied from Furo, with modifications as stated below. Modifications are marked 'mod:'. #}
 
 <div class="related-pages">
+  {# mod: Per-page navigation #}
   {% if meta %}
     {% if 'sequential_nav' in meta %}
       {% set sequential_nav = meta.sequential_nav %}
     {% endif %}  
   {% endif %}
+  {# mod: Conditional wrappers to control page navigation buttons #}
   {% if sequential_nav != "none" -%}
     {% if next and (sequential_nav == "next" or sequential_nav == "both") -%}
       <a class="next-page" href="{{ next.link }}">
@@ -51,7 +53,7 @@
     </div>
     {%- endif %}
 
-    {# ru-fu: removed "Made with" #}
+    {# mod: removed "Made with" #}
 
     {%- if last_updated -%}
     <div class="last-updated">
@@ -70,7 +72,7 @@
   </div>
   <div class="right-details">
 
-    {# ru-fu: replaced RTD icons with our links #}
+    {# mod: replaced RTD icons with our links #}
 
     {% if discourse %}
     <div class="ask-discourse">

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -76,7 +76,11 @@ html_context = {
 
     # Change to an empty value if your GitHub repo doesn't have issues enabled.
     # This will disable the feedback button and the issue link in the footer.
-    'github_issues': 'enabled'
+    'github_issues': 'enabled',
+
+    # Controls the existence of Previous / Next buttons at the bottom of pages
+    # Valid options: none, prev, next, both
+    'sequential_nav': "none"
 }
 
 # If your project is on documentation.ubuntu.com, specify the project


### PR DESCRIPTION
Closes #94.
Added new custom variable. 4 options for controlling sequential nav buttons.

To test:

- `make run`
- Play around with different values for the `sequential_nav` option in `cutom_conf.py` - "both", "none", "next", "prev" - and see the effect on the buttons. Note: an unexpected value like "blah" should be treated as "none"