### PR TITLE
don't totally exclude `doc-cheat-sheet*`

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -67,7 +67,6 @@ exclude_patterns = [
     'Thumbs.db',
     '.DS_Store',
     '.sphinx',
-    'doc-cheat-sheet*',
 ]
 exclude_patterns.extend(custom_excludes)
 

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -119,7 +119,9 @@ custom_linkcheck_anchors_ignore_for_url = [
 custom_extensions = []
 
 # Add files or directories that should be excluded from processing.
-custom_excludes = []
+custom_excludes = [
+    'doc-cheat-sheet*',
+]
 
 # Add CSS files (located in .sphinx/_static/)
 custom_html_css_files = []


### PR DESCRIPTION
There might be projects (like LXD ...) that have a "doc-cheat-sheet*" file as part of their documentation.
Therefore, we shouldn't exclude this file in conf.py (which projects shouldn't modify), but in custom_conf.py.