### PR TITLE
prevent overwriting existing window.onload functions

### DIFF
--- a/.sphinx/_static/github_issue_links.js
+++ b/.sphinx/_static/github_issue_links.js
@@ -1,4 +1,12 @@
+// if we already have an onload function, save that one
+var prev_handler = window.onload;
+
 window.onload = function() {
+    // call the previous onload function
+    if (prev_handler) {
+        prev_handler();
+    }
+
     const link = document.createElement("a");
     link.classList.add("muted-link");
     link.classList.add("github-issue-link");


### PR DESCRIPTION
If another JavaScript already defines a window.onload function, including the `github_issue_links.js` script will overwrite that function.
To prevent this, save the function that is already defined (if there is none, it'll just be empty, so no problem) and add it back as part of the function we're defining.