### PR TITLE
Custom wordlist

### DIFF
--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -6,6 +6,7 @@ matrix:
   dictionary:
     wordlists:
     - .wordlist.txt
+    - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
   - _build/**/*.html

--- a/readme.rst
+++ b/readme.rst
@@ -169,7 +169,7 @@ Configure the spelling check
 If your documentation uses US English instead of UK English, change this in the
 ``.sphinx/spellingcheck.yaml`` file.
 
-To add exceptions for words the spelling check marks as wrong even though they are correct, edit the ``.wordlist.txt`` file.
+To add exceptions for words the spelling check marks as wrong even though they are correct, edit the ``.custom_wordlist.txt`` file. It's recommended not to edit ``.wordlist.txt``, as this is intended to for words that apply across all projects and will be centrally maintained and updated.
 
 Configure the inclusive-language check
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/readme.rst
+++ b/readme.rst
@@ -169,7 +169,8 @@ Configure the spelling check
 If your documentation uses US English instead of UK English, change this in the
 ``.sphinx/spellingcheck.yaml`` file.
 
-To add exceptions for words the spelling check marks as wrong even though they are correct, edit the ``.custom_wordlist.txt`` file. It's recommended not to edit ``.wordlist.txt``, as this is intended to for words that apply across all projects and will be centrally maintained and updated.
+To add exceptions for words the spelling check marks as wrong even though they are correct, edit the ``.custom_wordlist.txt`` file. 
+You shouldn't edit ``.wordlist.txt``, because this file is maintained and updated centrally and contains words that apply across all projects.
 
 Configure the inclusive-language check
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Project-specific jargon should go here. This prevents collisions with updates to common wordlist. Closes #108.

## Suggested Test Steps

- Make spelling - should pass (confirming no regression of happy case)
- Modify `readme.rst` with some fake non-word like “nonwordicus”
- Make spelling - should fail (confirm no regression of failure case)
- Update the custom wordlist with the same fake non-word e.g. “nonwordicus”
- Make spelling - should now pass (confirming new functionality works)
