### PR TITLE
Makefile: ensure venv's pip is used throughout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(VENVDIR): $(SPHINXDIR)/requirements.txt
         --log $(VENVDIR)/pip_install.log
 	@test ! -f $(VENVDIR)/pip_list.txt || \
         mv $(VENVDIR)/pip_list.txt $(VENVDIR)/pip_list.txt.bak
-	@pip list --local --format=freeze > $(VENVDIR)/pip_list.txt
+	@. $(VENV); pip list --local --format=freeze > $(VENVDIR)/pip_list.txt
 	@echo "\n" \
         "--------------------------------------------------------------- \n" \
         "* watch, build and serve the documentation: make run \n" \


### PR DESCRIPTION
Previously, this recipe malfunctioned because `make` runs each recipe line in a separate shell instance. Now, venv is activated for logging as well. 