### PR TITLE
Exit 1 on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ linkcheck: install
 
 woke: woke-install
 	woke *.rst **/*.rst \
+		--exit-1-on-failure \
         -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
 .PHONY: woke


### PR DESCRIPTION
Causes a non-zero exit status when there are findings.

To test locally:

1. Checkout `main` branch
2. Edit some file to include a disallowed word (e.g. edit `readme.rst` by adding "master")
3. Run `make woke`
4. Observe that there is a "finding" reported by woke, warning of the use of the disallowed word
5. Run `echo $?` immediately afterwards - it should output `0`, indicating successful exit status

Repeat the above steps again on this branch. Notice that the command exits with non-zero exit status this time.