### PR TITLE
Fix 'help' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ VENV          = $(VENVDIR)/bin/activate
 
 
 # Put it first so that "make" without argument is like "make help".
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+help: $(VENVDIR)
+	@. $(VENV); $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help
 


### PR DESCRIPTION
Fixes #122 

This adds:
* Sourcing of the `activate` script in the command of the `help` target, so that the `sphinx-build` script is in the PATH and can be executed.
* The `$(VENVDIR)` target as a prereq to the `help` target, so that `make help` doesn't fail when run without some other target first creating the virt. env. 