### PR TITLE
spelling check: exclude commands

### DIFF
--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -23,6 +23,7 @@ matrix:
       - link
       - title
       - div.relatedlinks
+      - strong.command
       - div.visually-hidden
       - img
       - a.p-navigation__link


### PR DESCRIPTION
Commands that are marked up with ``:command:`abc` `` in rST should not be checked by the spelling checker.