### PR TITLE
Reformat Makefile for readability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ BUILDDIR      = _build
 VENVDIR       = $(SPHINXDIR)/venv
 VENV          = $(VENVDIR)/bin/activate
 
+.PHONY: help woke-install install run html epub serve clean clean-doc \
+        spelling linkcheck woke Makefile
 
 # Put it first so that "make" without argument is like "make help".
 help: $(VENVDIR)
 	@. $(VENV); $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-.PHONY: help
 
 # Explicit target avoids fall-through to the "Makefile" target.
 $(SPHINXDIR)/requirements.txt:
@@ -27,10 +27,10 @@ $(VENVDIR): $(SPHINXDIR)/requirements.txt
 	@echo "... setting up virtualenv"
 	python3 -m venv $(VENVDIR)
 	. $(VENV); pip install --require-virtualenv \
-        --upgrade -r $(SPHINXDIR)/requirements.txt \
-        --log $(VENVDIR)/pip_install.log
+	    --upgrade -r $(SPHINXDIR)/requirements.txt \
+            --log $(VENVDIR)/pip_install.log
 	@test ! -f $(VENVDIR)/pip_list.txt || \
-        mv $(VENVDIR)/pip_list.txt $(VENVDIR)/pip_list.txt.bak
+            mv $(VENVDIR)/pip_list.txt $(VENVDIR)/pip_list.txt.bak
 	@. $(VENV); pip list --local --format=freeze > $(VENVDIR)/pip_list.txt
 	@echo "\n" \
         "--------------------------------------------------------------- \n" \
@@ -39,92 +39,51 @@ $(VENVDIR): $(SPHINXDIR)/requirements.txt
         "* only serve: make serve \n" \
         "* clean built doc files: make clean-doc \n" \
         "* clean full environment: make clean \n" \
+        "* check links: make linkcheck \n" \
         "* check spelling: make spelling \n" \
         "* check inclusive language: make woke \n" \
         "* other possible targets: make <press TAB twice> \n" \
         "--------------------------------------------------------------- \n"
 	@touch $(VENVDIR)
 
-
 woke-install:
 	@type woke >/dev/null 2>&1 || \
-        { echo "Installing \"woke\" snap... \n"; sudo snap install woke; }
-
-.PHONY:  woke-install
-
+            { echo "Installing \"woke\" snap... \n"; sudo snap install woke; }
 
 install: $(VENVDIR) woke-install
 
-.PHONY:  install
-
-
 run: install
-	. $(VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" \
-	$(SPHINXOPTS)
-
-.PHONY: run
+	. $(VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 html: install
-	. $(VENV); $(SPHINXBUILD) -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" \
-        -w .sphinx/warnings.txt $(SPHINXOPTS)
-
-.PHONY: html
-
+	. $(VENV); $(SPHINXBUILD) -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w .sphinx/warnings.txt $(SPHINXOPTS)
 
 epub: install
-	. $(VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)" \
-        -w .sphinx/warnings.txt $(SPHINXOPTS)
-
-.PHONY: epub
-
+	. $(VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w .sphinx/warnings.txt $(SPHINXOPTS)
 
 serve: html
 	cd "$(BUILDDIR)"; python3 -m http.server 8000
 
-.PHONY: serve
-
-
 clean: clean-doc
-	@test ! -e "$(VENVDIR)" -o \
-        -d "$(VENVDIR)" -a "$(abspath $(VENVDIR))" != "$(VENVDIR)"
+	@test ! -e "$(VENVDIR)" -o -d "$(VENVDIR)" -a "$(abspath $(VENVDIR))" != "$(VENVDIR)"
 	rm -rf $(VENVDIR)
 	rm -rf .sphinx/.doctrees
-
-.PHONY: clean
-
 
 clean-doc:
 	git clean -fx "$(BUILDDIR)"
 
-.PHONY: clean-doc
-
-
 spelling: html
 	. $(VENV) ; python3 -m pyspelling -c .sphinx/spellingcheck.yaml
 
-.PHONY: spelling
-
-
 linkcheck: install
-	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" \
-	$(SPHINXOPTS)
-
-.PHONY: linkcheck
-
+	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 woke: woke-install
-	woke *.rst **/*.rst \
-		--exit-1-on-failure \
-        -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
-
-.PHONY: woke
-
+	woke *.rst **/*.rst --exit-1-on-failure \
+	    -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	. $(VENV); \
-        $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-.PHONY: Makefile
+	. $(VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
Fixes #130 & [DOCPR-179](https://warthogs.atlassian.net/browse/DOCPR-179)

* Adds indentation to multi-line commands
* Removes line breaks in commands where not needed
* Removes empty lines where not needed
* Puts all PHONY targets on one line
* Adds info about the `linkcheck` target

[DOCPR-179]: https://warthogs.atlassian.net/browse/DOCPR-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ