### PR TITLE
init script: create link for .wokeignore

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -31,12 +31,17 @@ cp -R "$temp_directory"/* "$temp_directory"/.??* "$install_directory"
 
 # Move workflow files and configuration
 if [ "$install_directory" != "." ]; then
-    echo "Moving workflow files and configuration..."       
+    echo "Moving workflow files and configuration..."
     if [ ! -d .github/workflows ]; then
         mkdir -p .github/workflows
     fi
     mv "$install_directory/.github/workflows"/* .github/workflows
     mv "$install_directory/.github/.jira_sync_config.yaml" .github/
+    if [ ! -f .wokeignore ]; then
+        ln -s "$install_directory/.wokeignore"
+    else
+        echo "ACTION REQUIRED: Found a .wokeignore file in the root directory. Include the contents from $install_directory/.wokeignore in this file!"
+    fi
 fi
 
 # Clean up

--- a/readme.rst
+++ b/readme.rst
@@ -53,6 +53,7 @@ To add documentation to an existing code repository:
 #. copy the file(s) located in the ``docs/.github/workflows`` directory into
    the code repository's ``.github/workflows`` directory
 #. in the above workflow file(s), change the value of the ``working-directory`` field from ``.`` to ``docs``
+#. create a symbolic link to the ``docs/.wokeignore`` file from the root directory of the code repository
 #. in file ``docs/.readthedocs.yaml`` set the following:
 
    * ``configuration: docs/conf.py``


### PR DESCRIPTION
When running woke locally, the .wokeignore file must be in the folder where you run it (for example, the `docs` folder). When runnin on GitHub, we run woke from the root folder though, and it cannot deal with a .wokeignore file in a subdirectory. Therefore, have the script create a symlink (unless there already is a .wokeignore file in the root folder).