### PR TITLE
remove handling of .jira_sync_config.yaml from the setup script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -36,7 +36,6 @@ if [ "$install_directory" != "." ]; then
         mkdir -p .github/workflows
     fi
     mv "$install_directory/.github/workflows"/* .github/workflows
-    mv "$install_directory/.github/.jira_sync_config.yaml" .github/
     if [ ! -f .wokeignore ]; then
         ln -s "$install_directory/.wokeignore"
     else


### PR DESCRIPTION
We removed the file from the starter pack, so need to remove it from the setup script as well.