### PR TITLE
Do not center table headers by default

### DIFF
--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -13,6 +13,7 @@ div.page, h1, h2, h3, h4, h5, h6, .sidebar-tree .current-page>.reference, button
 th.head {
     text-transform: uppercase;
     font-size: var(--font-size--small);
+    text-align: initial;
 }
 
 table.docutils {


### PR DESCRIPTION
The `furo` base theme centers table headers. This looks weird in my opinion for tables with only a few columns. See for example:

![image](https://github.com/canonical/sphinx-docs-starter-pack/assets/23220572/3af51f85-bdec-4d31-b536-f46c0f283567)

The source, so that you can play around with the style yourself:

```reStructuredText
+-------------------+--------------------+
|         `lorem`   | `ipsum`            |
+===================+====================+
| dolor             | sit                |
+-------------------+--------------------+
| amet              | consectetur        |
+-------------------+--------------------+
| adipiscing        | eli                |
+-------------------+--------------------+
| sed               | do                 |
+-------------------+--------------------+
```

Centering table headers with this change is still possible, for example:

```reStructuredText
.. role:: center
   :class: align-center

+-------------------+--------------------+
| :center:`lorem`   | :center:`ipsum`    |
+===================+====================+
| dolor             | sit                |
+-------------------+--------------------+
| amet              | consectetur        |
+-------------------+--------------------+
| adipiscing        | eli                |
+-------------------+--------------------+
| sed               | do                 |
+-------------------+--------------------+
```

This uses the style of `table.align-center` defined in `custom.css`:

https://github.com/canonical/sphinx-docs-starter-pack/blob/1393e0b8b1fe2cd555bba38d80473fd67767a34d/.sphinx/_static/custom.css#L29-L32