### PR TITLE
add note about fixing Python locale error

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -109,6 +109,10 @@ This will do several things:
 The ``run`` target is therefore very convenient when preparing to submit a
 change to the documentation.
 
+.. note:: 
+
+   If you encounter the error ``locale.Error: unsupported locale setting`` when activating the Python virtual environment, include the environment variable in the command and try again: ``LC_ALL=en_US.UTF-8 make run``.
+
 Local checks
 ~~~~~~~~~~~~
 

--- a/readme.rst
+++ b/readme.rst
@@ -111,7 +111,7 @@ change to the documentation.
 
 .. note:: 
 
-   If you encounter the error ``locale.Error: unsupported locale setting`` when activating the Python virtual environment, include the environment variable in the command and try again: ``LC_ALL=en_US.UTF-8 make run``.
+   If you encounter the error ``locale.Error: unsupported locale setting`` when activating the Python virtual environment, include the environment variable in the command and try again: ``LC_ALL=en_US.UTF-8 make run``
 
 Local checks
 ~~~~~~~~~~~~


### PR DESCRIPTION
## Description

This PR adds a note in Readme about how to resolve locale errors when activating the Python virtual environment. Some users may encounter a Python locale error when they use `make run`. This might be caused by the system environment variable `locale.LC_ALL` being empty. Adding the locale setting as a prefix in the make command resolves this issue.

(Users may also choose to change this environment variable for their local dev environment, but there is a risk of causing other conflicts.)

## Background

Error stack trace reported by a team member:
```
. .sphinx/venv/bin/activate; sphinx-autobuild -b dirhtml "." "_build" -c . -d .sphinx/.doctrees
[sphinx-autobuild] > sphinx-build -b dirhtml -d .sphinx/.doctrees -c . /home/user/code/hexr/docs /home/user/code/hexr/docs/_build
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/user/code/hexr/docs/.sphinx/venv/lib/python3.10/site-packages/sphinx/__main__.py", line 7, in <module>
    raise SystemExit(main(sys.argv[1:]))
  File "/home/user/code/hexr/docs/.sphinx/venv/lib/python3.10/site-packages/sphinx/cmd/build.py", line 326, in main
    locale.setlocale(locale.LC_ALL, '')
  File "/usr/lib/python3.10/locale.py", line 620, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
Command exited with exit code: 1
The server will continue serving the build folder, but the contents being served are no longer in sync with the documentation sources. Please fix the cause of the error above or press Ctrl+C to stop the server.
```