### PR TITLE
Remove sphinx tabs extension

### DIFF
--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -33,7 +33,7 @@ table.align-center {
 
 /** No rounded corners **/
 
-.admonition, code.literal, .sphinx-tabs-tab, .sphinx-tabs-panel, .highlight {
+.admonition, code.literal, .highlight {
     border-radius: 0;
 }
 
@@ -61,28 +61,6 @@ a.headerlink {
 
 [role="tablist"] {
     border-bottom: 1px solid var(--color-sidebar-item-background--hover);
-}
-
-.sphinx-tabs-tab[aria-selected="true"] {
-    border: 0;
-    border-bottom: 2px solid var(--color-brand-primary);
-    background-color: var(--color-sidebar-item-background--current);
-    font-weight:300;
-}
-
-.sphinx-tabs-tab{
-    color: var(--color-brand-primary);
-    font-weight:300;
-}
-
-.sphinx-tabs-panel {
-    border: 0;
-    border-bottom: 1px solid var(--color-sidebar-item-background--hover);
-    background: var(--color-background-primary);
-}
-
-button.sphinx-tabs-tab:hover {
-    background-color: var(--color-sidebar-item-background--hover);
 }
 
 /** Custom classes to fix scrolling in tables by decreasing the

--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -9,6 +9,5 @@ sphinx-copybutton
 sphinx-design
 sphinx-notfound-page
 sphinx-reredirects
-sphinx-tabs
 sphinxcontrib-jquery
 sphinxext-opengraph

--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,6 @@ from custom_conf import *
 
 extensions = [
     'sphinx_design',
-    'sphinx_tabs.tabs',
     'sphinx_reredirects',
     'canonical.youtube-links',
     'canonical.related-links',

--- a/doc-cheat-sheet-myst.md
+++ b/doc-cheat-sheet-myst.md
@@ -189,16 +189,21 @@ Keys can be defined at the top of a file, or in a `myst_substitutions` option in
 
 ## Tabs
 
-````{tabs}
-```{group-tab} Tab 1
+::::{tab-set}
 
-Content Tab 1
-```
+:::{tab-item} Label1
+:sync: key1
 
-```{group-tab} Tab 2
-Content Tab 2
-```
-````
+Content 1
+:::
+
+:::{tab-item} Label2
+:sync: key2
+
+Content 2
+:::
+
+::::
 
 ## Glossary
 

--- a/doc-cheat-sheet.rst
+++ b/doc-cheat-sheet.rst
@@ -195,16 +195,17 @@ Reuse
 Tabs
 ----
 
-.. tabs::
+.. tab-set::
 
-   .. group-tab:: Tab 1
+    .. tab-item:: Label1
+        :sync: key1
 
-      Content Tab 1
+        Content 1
 
-   .. group-tab:: Tab 2
+    .. tab-item:: Label2
+        :sync: key2
 
-      Content Tab 2
-
+        Content 2
 
 Glossary
 --------

--- a/readme.rst
+++ b/readme.rst
@@ -276,7 +276,6 @@ They are pre-configured as needed, but you can customise their configuration in 
 The following extensions are always included:
 
 - |sphinx-design|_
-- |sphinx_tabs.tabs|_
 - |sphinx_reredirects|_
 - |lxd-sphinx-extensions|_ (``youtube-links``, ``related-links``, ``custom-rst-roles``, and ``terminal-output``)
 - |sphinx_copybutton|_
@@ -320,8 +319,6 @@ See the `change log <https://github.com/canonical/sphinx-docs-starter-pack/wiki/
 
 .. |sphinx-design| replace:: ``sphinx-design``
 .. _sphinx-design: https://sphinx-design.readthedocs.io/en/latest/
-.. |sphinx_tabs.tabs| replace:: ``sphinx_tabs.tabs``
-.. _sphinx_tabs.tabs: https://sphinx-tabs.readthedocs.io/en/latest/
 .. |sphinx_reredirects| replace:: ``sphinx_reredirects``
 .. _sphinx_reredirects: https://documatt.gitlab.io/sphinx-reredirects/
 .. |lxd-sphinx-extensions| replace:: ``lxd-sphinx-extensions``


### PR DESCRIPTION
The `sphinx-design` extension already provides a tabs feature, see:
https://sphinx-design.readthedocs.io/en/latest/tabs.html