### PR TITLE
amend 'make pa11y' target to work with GitHub Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ woke: woke-install
 	    -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
 pa11y: pa11y-install html
-	find $(BUILDDIR) -name *.html -exec $(PA11Y) {} \;
+	find $(BUILDDIR) -name *.html -print0 | xargs -n 1 -0 $(PA11Y)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
This enables proper failure reporting in GitHub workflows that rely on the continue-on-error mechanism at the step/job level.

Links:
- <https://github.com/orgs/community/discussions/15452>