### PR TITLE
Fix the logic for cleaning doctrees directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,10 @@ serve: html
 clean: clean-doc
 	@test ! -e "$(VENVDIR)" -o -d "$(VENVDIR)" -a "$(abspath $(VENVDIR))" != "$(VENVDIR)"
 	rm -rf $(VENVDIR)
-	rm -rf .sphinx/.doctrees
 
 clean-doc:
 	git clean -fx "$(BUILDDIR)"
+	rm -rf .sphinx/.doctrees
 
 spelling: html
 	. $(VENV) ; python3 -m pyspelling -c .sphinx/spellingcheck.yaml


### PR DESCRIPTION
Move the removal logic for directory `.sphinx/.doctrees` from the `clean` make target to the `clean-doc` make target.