### PR TITLE
fix target name in myst cheat sheet

### DIFF
--- a/doc-cheat-sheet-myst.md
+++ b/doc-cheat-sheet-myst.md
@@ -53,7 +53,7 @@ code:
   - example: true
 ```
 
-(_a_section_target)=
+(a_section_target)=
 ## Links
 
 - [Canonical website](https://canonical.com/)

--- a/doc-cheat-sheet-myst.md
+++ b/doc-cheat-sheet-myst.md
@@ -53,13 +53,13 @@ code:
   - example: true
 ```
 
-(a_section_target)=
+(a_section_target_myst)=
 ## Links
 
 - [Canonical website](https://canonical.com/)
 - https:/<span></span>/canonical.com/
-- {ref}`a_section_target`
-- {ref}`Link text <a_section_target>`
+- {ref}`a_section_target_myst`
+- {ref}`Link text <a_section_target_myst>`
 - {doc}`index`
 - {doc}`Link text <index>`
 


### PR DESCRIPTION
Fix syntax error -  target name (string between parenthesis) and the reference link did not match.

Also, since the target name "a_section_target" has been defined in RST, so I added a suffix to illustrate that targets in RST and MyST should not duplicate.