### PR TITLE
docs: add remark about Read the Docs redirects

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -115,6 +115,8 @@ slug = ""
 
 # Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 # For example: 'explanation/old-name.html': '../how-to/prettify.html',
+# You can also configure redirects in the Read the Docs project dashboard
+# (see https://docs.readthedocs.io/en/stable/guides/redirects.html).
 # NOTE: If this variable is not defined, set to None, or the dictionary is empty,
 # the sphinx_reredirects extension will be disabled.
 redirects = {}


### PR DESCRIPTION
Redirects can be configured with the ReadTheDocs admin dashboard. No project side redirects required.

See https://docs.readthedocs.io/en/stable/guides/redirects.html