### PR TITLE
fix: Makefile improvements for venv, woke, pa11y, 'clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ clean: clean-doc
 	@test ! -e "$(VENVDIR)" -o -d "$(VENVDIR)" -a "$(abspath $(VENVDIR))" != "$(VENVDIR)"
 	rm -rf $(VENVDIR)
 	rm -f $(SPHINXDIR)/requirements.txt
+	rm -rf $(SPHINXDIR)/node_modules/
 
 clean-doc:
 	git clean -fx "$(BUILDDIR)"


### PR DESCRIPTION
This fixes a bug that caused `make install` to fail if there was no `venv` module available, which may be the case on Debian/Ubuntu systems ([1], also mentioned in Python's error message).

Also, this PR removes `install`'s dependency on `woke-install`; while the check itself is mandatory, having separate `*-install` targets for doc check tools is a more consistent arrangement.

Links:
[1] <https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847>