### PR TITLE
move build_requirements.py to .sphinx folder

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.11"
   jobs:
     post_checkout:
-      - python3 build_requirements.py
+      - python3 .sphinx/build_requirements.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.sphinx/build_requirements.py
+++ b/.sphinx/build_requirements.py
@@ -42,11 +42,11 @@ def AreRedirectsDefined():
 def IsOpenGraphConfigured():
     if "sphinxext.opengraph" in custom_extensions:
         return True
-    
+
     for global_variable_name in list(globals()):
         if global_variable_name.startswith("ogp_"):
             return True
-    
+
     return False
 
 def IsMyStParserUsed():
@@ -61,7 +61,7 @@ def DeduplicateExtensions(extensionNames: [str]):
     for extensionName in extensionNames:
         if extensionName in legacyCanonicalSphinxExtensionNames:
             extensionName = "canonical." + extensionName
-            
+
         if extensionName.startswith("canonical."):
             if extensionName not in encounteredCanonicalExtensions:
                 encounteredCanonicalExtensions.append(extensionName)
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         "sphinx-design",
         "sphinxcontrib-jquery"
     ]
-    
+
     requirements.extend(custom_required_modules)
 
     if IsAnyCanonicalSphinxExtensionUsed():
@@ -112,7 +112,7 @@ if __name__ == "__main__":
             "# Add custom requirements to the custom_required_modules\n"
             "# array in the custom_conf.py file and run:\n"
             "# make clean && make install\n")
-        
-        for requirement in requirements:    
+
+        for requirement in requirements:
             requirements_file.write(requirement)
             requirements_file.write('\n')

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ full-help: $(VENVDIR)
 # Shouldn't assume that venv is available on Ubuntu by default; discussion here:
 # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847
 $(SPHINXDIR)/requirements.txt:
-	python3 build_requirements.py
+	python3 $(SPHINXDIR)/build_requirements.py
 	python3 -c "import venv" || sudo apt install python3-venv
 
 # If requirements are updated, venv should be rebuilt and timestamped.

--- a/conf.py
+++ b/conf.py
@@ -2,6 +2,7 @@ import sys
 
 sys.path.append('./')
 from custom_conf import *
+sys.path.append('.sphinx/')
 from build_requirements import *
 
 # Configuration file for the Sphinx documentation builder.
@@ -41,7 +42,7 @@ if IsMyStParserUsed():
 # Only add Open Graph extension if any configuration is present.
 if IsOpenGraphConfigured():
     extensions.append('sphinxext.opengraph')
-    
+
 extensions.extend(custom_extensions)
 extensions = DeduplicateExtensions(extensions)
 

--- a/init.sh
+++ b/init.sh
@@ -16,7 +16,7 @@ rm -rf "$temp_directory/.git"
 echo "Updating working directory in workflow files..."
 sed -i "s|working-directory:\s*'\.'|working-directory: '$install_directory'|g" "$temp_directory/.github/workflows"/*
 echo "Updating .readthedocs.yaml configuration..."
-sed -i "s|-\s\s*python3\s\s*build_requirements\.py|- cd '$install_directory' \&\& python3 build_requirements.py|g" "$temp_directory/.readthedocs.yaml"
+sed -i "s|-\s\s*python3\s\s*.sphinx/build_requirements\.py|- cd '$install_directory' \&\& python3 .sphinx/build_requirements.py|g" "$temp_directory/.readthedocs.yaml"
 sed -i "s|configuration:\s*conf\.py|configuration: $install_directory/conf.py|g" "$temp_directory/.readthedocs.yaml"
 sed -i "s|requirements:\s*\.sphinx/requirements\.txt|requirements: $install_directory/.sphinx/requirements.txt|g" "$temp_directory/.readthedocs.yaml"
 

--- a/readme.rst
+++ b/readme.rst
@@ -172,7 +172,7 @@ To add documentation to an existing code repository:
 #. create a symbolic link to the ``docs/.wokeignore`` file from the root directory of the code repository
 #. in file ``docs/.readthedocs.yaml`` set the following:
 
-   * ``post_checkout: cd docs && python3 build_requirements.py``
+   * ``post_checkout: cd docs && python3 .sphinx/build_requirements.py``
    * ``configuration: docs/conf.py``
    * ``requirements: docs/.sphinx/requirements.txt``
 


### PR DESCRIPTION
The script shouldn't be on the root level, since users don't need to know about it.

Adresses #183
