### PR TITLE
fix colour for links in dark mode

### DIFF
--- a/.sphinx/_static/furo_colors.css
+++ b/.sphinx/_static/furo_colors.css
@@ -40,7 +40,7 @@ body {
         --color-background-secondary: var(--color-background-primary);
         --color-background-hover: #666;
         --color-brand-primary: #fff;
-        --color-brand-content: #06C;
+        --color-brand-content: #69C;
         --color-sidebar-link-text: #f7f7f7;
         --color-sidebar-item-background--current: #666;
         --color-sidebar-item-background--hover: #333;
@@ -67,7 +67,7 @@ body {
             --color-background-secondary: var(--color-background-primary);
             --color-background-hover: #666;
             --color-brand-primary: #fff;
-            --color-brand-content: #06C;
+            --color-brand-content: #69C;
             --color-sidebar-link-text: #f7f7f7;
             --color-sidebar-item-background--current: #666;
             --color-sidebar-item-background--hover: #333;


### PR DESCRIPTION
Use the colour that Vanilla uses for dark mode:
https://vanillaframework.io/docs/patterns/links#dark

See https://github.com/canonical/lxd/issues/13062