### PR TITLE
change build job for build_requirements.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   tools:
     python: "3.11"
   jobs:
-    post_checkout:
+    pre_install:
       - python3 .sphinx/build_requirements.py
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
Changing the build job to `pre_install` for the `build_requirements.py` script means that the build machine will already be fully set up, so that you can use pip to install any packages that are required in `custom_conf.py` and will otherwise give errors.

This is required to work around #197.