### PR TITLE
fix font size for code in admonitions

### DIFF
--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -347,3 +347,8 @@ p code.literal {
     border: 0;
     font-size: var(--code-font-size);
 }
+
+/* Use the general admonition font size for inline code */
+.admonition p code.literal {
+    font-size: var(--admonition-font-size);
+}


### PR DESCRIPTION
The font size for admonitions is smaller than the normal font size. Make sure that inline code in admonitions displays at the same (smaller) size.