### PR TITLE
feat: support Matrix link in footer

### DIFF
--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -86,6 +86,12 @@
     </div>
     {% endif %}
 
+    {% if matrix %}
+    <div class="ask-matrix">
+      <a class="muted-link" href="{{ matrix }}">Ask a question on Matrix</a>
+    </div>
+    {% endif %}
+
     {% if github_url and github_version and github_folder %}
 
     {% if github_issues %}

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -23,6 +23,7 @@ Kubernetes
 Launchpad
 LTS
 Makefile
+Matrix
 Mattermost
 MyST
 namespace

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -85,7 +85,7 @@ html_context = {
 
     # Change to the Matrix channel you want to link to
     # (use an empty value if you don't want to link)
-    'matrix': 'https://matrix.to/#/#room-address:ubuntu.com',
+    'matrix': 'https://matrix.to/#/#documentation:ubuntu.com',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/starter-pack',

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -83,6 +83,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/documentation',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#room-address:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/starter-pack',
 


### PR DESCRIPTION
Juju/Ops Framework use Matrix instead of Mattermost, would be nice if the template supports Mattermost.

Closes https://github.com/canonical/sphinx-docs-starter-pack/issues/206.