### PR TITLE
feat: adjust API link underline color and API background color

### DIFF
--- a/.sphinx/_static/furo_colors.css
+++ b/.sphinx/_static/furo_colors.css
@@ -8,7 +8,7 @@ body {
     --color-foreground-secondary: var(--color-foreground-primary);
     --color-foreground-muted: #333;
     --color-background-secondary: #FFF;
-    --color-background-hover: #f2f2f2;
+    --color-background-hover: #CDCDCD;
     --color-brand-primary: #111;
     --color-brand-content: #06C;
     --color-api-background: #f2f2f2;
@@ -39,7 +39,7 @@ body {
         --color-foreground-secondary: var(--color-foreground-primary);
         --color-foreground-muted: #CDCDCD;
         --color-background-secondary: var(--color-background-primary);
-        --color-background-hover: #CDCDCD;
+        --color-background-hover: #666;
         --color-brand-primary: #fff;
         --color-brand-content: #06C;
         --color-api-background: #333;
@@ -68,7 +68,7 @@ body {
             --color-foreground-secondary: var(--color-foreground-primary);
             --color-foreground-muted: #CDCDCD;
             --color-background-secondary: var(--color-background-primary);
-            --color-background-hover: #CDCDCD;
+            --color-background-hover: #666;
             --color-brand-primary: #fff;
             --color-brand-content: #06C;
             --color-api-background: #333;

--- a/.sphinx/_static/furo_colors.css
+++ b/.sphinx/_static/furo_colors.css
@@ -11,7 +11,8 @@ body {
     --color-background-hover: #f2f2f2;
     --color-brand-primary: #111;
     --color-brand-content: #06C;
-    --color-api-background: #cdcdcd;
+    --color-api-background: #f2f2f2;
+    --color-api-background-hover: #cdcdcd;
     --color-inline-code-background: rgba(0,0,0,.03);
     --color-sidebar-link-text: #111;
     --color-sidebar-item-background--current: #ebebeb;
@@ -26,8 +27,8 @@ body {
     --color-admonition-title--important: #C7162B;
     --color-admonition-title--caution: #F99B11;
     --color-highlighted-background: #EBEBEB;
-    --color-link-underline: var(--color-background-primary);
-    --color-link-underline--hover: var(--color-background-primary);
+    --color-link-underline: var(--color-link);
+    --color-link-underline--hover: var(--color-link);
     --color-version-popup: #772953;
 }
 
@@ -38,9 +39,11 @@ body {
         --color-foreground-secondary: var(--color-foreground-primary);
         --color-foreground-muted: #CDCDCD;
         --color-background-secondary: var(--color-background-primary);
-        --color-background-hover: #666;
+        --color-background-hover: #CDCDCD;
         --color-brand-primary: #fff;
         --color-brand-content: #06C;
+        --color-api-background: #333;
+        --color-api-background-hover: #666;
         --color-sidebar-link-text: #f7f7f7;
         --color-sidebar-item-background--current: #666;
         --color-sidebar-item-background--hover: #333;
@@ -54,8 +57,8 @@ body {
         --color-admonition-title--important: #C7162B;
         --color-admonition-title--caution: #F99B11;
         --color-highlighted-background: #666;
-        --color-link-underline: var(--color-background-primary);
-        --color-link-underline--hover: var(--color-background-primary);
+        --color-link-underline: var(--color-link);
+        --color-link-underline--hover: var(--color-link);
         --color-version-popup: #F29879;
     }
     @media (prefers-color-scheme: dark) {
@@ -65,9 +68,11 @@ body {
             --color-foreground-secondary: var(--color-foreground-primary);
             --color-foreground-muted: #CDCDCD;
             --color-background-secondary: var(--color-background-primary);
-            --color-background-hover: #666;
+            --color-background-hover: #CDCDCD;
             --color-brand-primary: #fff;
             --color-brand-content: #06C;
+            --color-api-background: #333;
+            --color-api-background-hover: #666;
             --color-sidebar-link-text: #f7f7f7;
             --color-sidebar-item-background--current: #666;
             --color-sidebar-item-background--hover: #333;
@@ -81,8 +86,8 @@ body {
             --color-admonition-title--important: #C7162B;
             --color-admonition-title--caution: #F99B11;
             --color-highlighted-background: #666;
-            --color-link-underline: var(--color-background-primary);
-            --color-link-underline--hover: var(--color-background-primary);
+            --color-link-underline: var(--color-link);
+            --color-link-underline--hover: var(--color-link);
             --color-version-popup: #F29879;
         }
     }


### PR DESCRIPTION
Changes:

- Link underline in API should be blue, same as link text, no matter in light mode or dark mode.
- Light mode API background uses a much lighter grey to match "light" mode. On hover it becomes slightly darker to pop up (even lighter doesn't work).
- Dark mode API background uses a much darker grey to match "dark" mode. On hover it becomes slightly lighter to pop up.

Closes https://github.com/canonical/sphinx-docs-starter-pack/issues/209.

---

# Preview

## Light Mode

Before:

<img width="839" alt="light-mode" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/b18f7de9-f124-4882-ae85-62c425a24547">

After:

<img width="828" alt="light-mode-changed" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/d5ff1320-62cb-4525-a3b3-f7694042fc51">

## Light Mode Hover

Before:

<img width="844" alt="light-mode-hover" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/74810c23-bcb1-48fb-b94a-374b2fd8419e">

After:

<img width="835" alt="light-mode-hover-changed" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/1d2d1110-08e5-4035-a0d8-8f4b0b549f9d">

## Dark Mode

Before:

<img width="845" alt="dark-mode" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/9b3b8959-d257-4138-9994-da6799373943">

After:

<img width="832" alt="dark-mode-changed" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/697680f1-36ad-4838-a33b-c23bffb8b5f1">

## Dark Mode Hover

Before:

<img width="842" alt="dark-mode-hover" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/a75bea67-bf45-4937-a899-b5b16c5bc98c">

After:

<img width="836" alt="dark-mode-hover-changed" src="https://github.com/canonical/sphinx-docs-starter-pack/assets/19277614/c61282b1-c4a4-4382-a4cb-e4356afba42c">
