### PR TITLE
Add the 'watchfiles' module for sphinx-autobuild

### DIFF
--- a/.sphinx/build_requirements.py
+++ b/.sphinx/build_requirements.py
@@ -82,7 +82,8 @@ if __name__ == "__main__":
         "sphinx-autobuild",
         "sphinx-copybutton",
         "sphinx-design",
-        "sphinxcontrib-jquery"
+        "sphinxcontrib-jquery",
+        "watchfiles",
     ]
 
     requirements.extend(custom_required_modules)


### PR DESCRIPTION
Adds the `watchfiles` module to `build_requirements.py` to fix #213.