### PR TITLE
fix: manpage url linkcheck failures

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,8 @@ build:
   jobs:
     post_checkout:
       - python3 .sphinx/build_requirements.py
+  apt_packages:
+    - distro-info
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -51,6 +51,8 @@ sp-pa11y-install:
 		}
 
 sp-install: $(VENVDIR)
+	sudo apt-get update
+	sudo apt-get install --assume-yes distro-info
 
 sp-run: sp-install
 	. $(VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)

--- a/conf.py
+++ b/conf.py
@@ -3,6 +3,7 @@ import os
 import requests
 from urllib.parse import urlparse
 from git import Repo
+import subprocess
 import time
 
 sys.path.append('./')
@@ -107,6 +108,15 @@ rst_epilog = '''
 '''
 if 'custom_rst_epilog' in locals():
     rst_epilog = custom_rst_epilog
+
+if 'custom_manpages_url' in locals():
+    manpages_url = custom_manpages_url
+else:
+    manpages_distribution = subprocess.check_output("distro-info --stable", 
+                                                text=True, shell=True).strip()
+    manpages_url = ("https://manpages.ubuntu.com/manpages/"
+                    f"{manpages_distribution}/en/"
+                    "man{section}/{page}.{section}.html")
 
 source_suffix = {
     '.rst': 'restructuredtext',

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -146,6 +146,9 @@ custom_linkcheck_anchors_ignore_for_url = []
 ### Additions to default configuration
 ############################################################
 
+# Uncomment to overwrite Ubuntu manpages URL template for :manpage: directives:
+# custom_manpages_url = "https://customurl/man{section}/{page}.{section}.html"
+
 ## The following settings are appended to the default configuration.
 ## Use them to extend the default functionality.
 # NOTE: Remove this variable to disable the MyST parser extensions.


### PR DESCRIPTION
The Ubuntu manpage urls return a "404 Not Found" error, because when verified by linkcheck the JavaScript code that will look up the searched manpage at runtime does not get executed.

To solve this error we staticaly define the URL that would otherwise be looked up at runtime. Therefore we use dist-info to look up the latest Ubuntu distribution.

One drawback is that the documentation has to periodically be regenerated, because a newer Ubuntu distribution will be released every 6 months.

Bug: #224