### PR TITLE
Update readme for docs in code flow

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -163,21 +163,23 @@ Documentation in a code repository
 
 To add documentation to an existing code repository:
 
-#. create a directory called ``docs`` at the root of the code repository
-#. populate the above directory with the contents of the starter pack
-   repository (with the exception of the ``.git`` directory)
-#. copy the file(s) located in the ``docs/.github/workflows`` directory into
-   the code repository's ``.github/workflows`` directory
-#. in the above workflow file(s), change the value of the ``working-directory`` field from ``.`` to ``docs``
-#. create a symbolic link to the ``docs/.wokeignore`` file from the root directory of the code repository
-#. in file ``docs/.readthedocs.yaml`` set the following:
+#. Create a directory called :file:`docs` at the root of the code repository.
+#. Populate the above directory with the contents of the starter pack
+   repository (with the exception of the :file:`.git` directory).
+#. Copy the file(s) located in the :file:`docs/.github/workflows` directory into
+   the :file:`.github/workflows` directory in the root of the code repository.
+#. In the above workflow file(s), change the value of the
+   :file:`working-directory` field from ``.`` to ``docs``.
+#. Create a symbolic link to the :file:`docs/.wokeignore` file from the root
+   directory of the code repository.
+#. In the :file:`docs/.readthedocs.yaml` file, set the following:
 
    * ``post_checkout: cd docs && python3 .sphinx/build_requirements.py``
    * ``configuration: docs/conf.py``
    * ``requirements: docs/.sphinx/requirements.txt``
 
-**Note:** When configuring RTD itself for your project, the setting "Path for
-``.readthedocs.yaml``" (under **Advanced Settings**) will need to be given the
+**Note:** When configuring RTD itself for your project, the setting \"Path for
+``.readthedocs.yaml``\" (under **Advanced Settings**) will need to be given the
 value of ``docs/.readthedocs.yaml``.
 
 Automation
@@ -185,22 +187,29 @@ Automation
 
 To automate the initialisation for either scenario ensure you have the following:
 
-- A GitHub repository where you want to host your documentation, cloned to your local machine. The recommended approach is to host the documentation alongside your code in a ``docs`` folder. But a standalone documentation repository is also an option; in this case, start with an empty repository.
+- A GitHub repository where you want to host your documentation, cloned to your
+  local machine. The recommended approach is to host the documentation alongside
+  your code in a :file:`docs` folder. But a standalone documentation repository
+  is also an option; in this case, start with an empty repository.
 - Git and Bash installed on your system.
 
-There is a provided ``init.sh`` Bash script that does the following:
+There is a provided :file:`init.sh` Bash script that does the following:
 
-- clones the starter pack GitHub repository
-- creates the specified installation directory if necessary
-- updates working directory paths in workflow files, and updates configuration paths in the ``.readthedocs.yaml`` file
-- copies and moves contents and ``.github`` files from the starter pack to the installation directory
-- deletes the cloned repository when it's done
+- Clones the starter pack GitHub repository.
+- Creates the specified installation directory (if necessary).
+- Updates working directory paths in workflow files, and updates configuration
+  paths in the :file:`.readthedocs.yaml` file.
+- Copies and moves contents and :file:`.github` files from the starter pack to
+  the installation directory.
+- Deletes the cloned repository when it\'s done.
 
 To use the script:
 
-#. copy ``init.sh`` to your repository's root directory
-#. run the script: ``./init.sh``
-#. enter the installation directory when prompted. For standalone repositories, enter ".". For documentation alongside code, enter the folder where your documentation is (e.g. ``docs``)
+#. Copy ``init.sh`` to your repository\'s root directory.
+#. Run the script: ``./init.sh``.
+#. Enter the installation directory when prompted. For standalone repositories,
+   enter ``.``. For documentation alongside code, enter the folder where your
+   documentation is (e.g. ``docs``).
 
 When the script completes, review all changes before committing them.
 
@@ -327,11 +336,11 @@ Work with your documentation
 ----------------------------
 
 This section is for documentation contributors. It assumes that the current
-repository has been initialised with the starter pack as described in
-section `Enable the starter pack`_.
+repository has been initialised with the starter pack as described in section
+`Enable the starter pack`_.
 
-There are make targets defined in the ``Makefile`` that do various things. To
-get started, we will:
+There are make targets defined in the :file:`Makefile` that do various things.
+To get started, we will:
 
 * install prerequisite software
 * view the documentation
@@ -339,15 +348,16 @@ get started, we will:
 Install prerequisite software
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Before you start, make sure you have ``make`` and ``python3`` on your system:
+Before you start, make sure you have ``make``, ``python3``, ``python3-venv``,
+and ``python3-pip`` on your system:
 
 .. code-block:: none
 
    sudo apt update
-   sudo apt install make python3
+   sudo apt install make python3 python3-venv python3-pip
 
-Some `validation tools <#local-checks>`_ won't be available by default;
-to install them, you need ``snap`` and ``npm``:
+Some `validation tools <#local-checks>`_ won't be available by default. To
+install them, you need ``snap`` and ``npm``:
 
 .. code-block:: none
 


### PR DESCRIPTION
Updated the README instructions ~~to work for docs-in-code repository workflow (related to issue #232), and~~ to indicate other prerequisite packages / software to account for new users who are possibly working with these repositories for the first time.

Added @giuliazanchi who also went through some pains to get things up and running for the first time.

Other updates are formatting / syntax related updates.

Thanks!

Note: `InvalidGitRepositoryError` will be fixed in PR https://github.com/canonical/sphinx-docs-starter-pack/pull/229 .