### PR TITLE
Get rid of apt install in the Makefile

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,6 @@ build:
     pre_install:
       - python3 .sphinx/build_requirements.py
       - git fetch --unshallow || true
-  apt_packages:
-    - distro-info
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -51,8 +51,6 @@ sp-pa11y-install:
 		}
 
 sp-install: $(VENVDIR)
-	sudo apt-get update
-	sudo apt-get install --assume-yes distro-info
 
 sp-run: sp-install
 	. $(VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -25,7 +25,8 @@ sp-full-help: $(VENVDIR)
 # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847
 $(SPHINXDIR)/requirements.txt:
 	python3 $(SPHINXDIR)/build_requirements.py
-	python3 -c "import venv" || sudo apt install python3-venv
+	python3 -c "import venv" || \
+        (echo "You must install python3-venv before you can build the documentation."; exit 1)
 
 # If requirements are updated, venv should be rebuilt and timestamped.
 $(VENVDIR): $(SPHINXDIR)/requirements.txt

--- a/conf.py
+++ b/conf.py
@@ -3,7 +3,6 @@ import os
 import requests
 from urllib.parse import urlparse
 from git import Repo, InvalidGitRepositoryError
-import subprocess
 import time
 
 sys.path.append('./')
@@ -108,15 +107,6 @@ rst_epilog = '''
 '''
 if 'custom_rst_epilog' in locals():
     rst_epilog = custom_rst_epilog
-
-if 'custom_manpages_url' in locals():
-    manpages_url = custom_manpages_url
-else:
-    manpages_distribution = subprocess.check_output("distro-info --stable",
-                                                text=True, shell=True).strip()
-    manpages_url = ("https://manpages.ubuntu.com/manpages/"
-                    f"{manpages_distribution}/en/"
-                    "man{section}/{page}.{section}.html")
 
 source_suffix = {
     '.rst': 'restructuredtext',

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -104,11 +104,11 @@ html_context = {
 
     # Controls the existence of Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
-    'sequential_nav': "none", 
-    
+    'sequential_nav': "none",
+
     # Controls if to display the contributors of a file or not
     "display_contributors": True,
-    
+
     # Controls time frame for showing the contributors
     "display_contributors_since": ""
 }
@@ -146,12 +146,10 @@ custom_linkcheck_anchors_ignore_for_url = []
 ### Additions to default configuration
 ############################################################
 
-# Uncomment to overwrite Ubuntu manpages URL template for :manpage: directives:
-# custom_manpages_url = "https://customurl/man{section}/{page}.{section}.html"
-
 ## The following settings are appended to the default configuration.
 ## Use them to extend the default functionality.
-# NOTE: Remove this variable to disable the MyST parser extensions.
+
+# Remove this variable to disable the MyST parser extensions.
 custom_myst_extensions = []
 
 # Add custom Sphinx extensions as needed.
@@ -202,6 +200,10 @@ disable_feedback_button = False
 # Add tags that you want to use for conditional inclusion of text
 # (https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#tags)
 custom_tags = []
+
+# If you are using the :manpage: role, set this variable to the URL for the version
+# that you want to link to:
+# manpages_url = "https://manpages.ubuntu.com/manpages/noble/en/man{section}/{page}.{section}.html"
 
 ############################################################
 ### Additional configuration


### PR DESCRIPTION
For the basic functionality of the starter pack, we should not assume that we are on Ubuntu.

Therefore, undo the change of automatically determining the manpages URL (instead, add the variable to `custom_conf.py` so every team that needs it can decide if they want to update it manually or add some automatic processing).

Also, don't automatically install python3-env if it's missing, but return an error message that it must be installed.