### PR TITLE
spelling: Add Dqlite to wordlist

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -8,6 +8,7 @@ balancer
 Charmhub
 CLI
 Diátaxis
+Dqlite
 dropdown
 EBS
 EKS


### PR DESCRIPTION
Looks like `Dqlite` is preferred in [the docs](https://dqlite.io/docs).