### PR TITLE
Refine triggers to avoid replicated runs on PRs

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -1,9 +1,12 @@
 name: Main Documentation Checks
 
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Manual trigger
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   # Manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
The workflow currently runs twice on PRs, on every commit from a branch:
![image](https://github.com/user-attachments/assets/9f9d3eda-df9e-409c-8c33-43fb06c69c8c)

This is because the trigger branch for push event isn't restricted to main.

This isn't an issue on PRs with a forked repo head, only on those from an internal branch.