### PR TITLE
Revert "cannot do parallel builds for now"

### DIFF
--- a/sp-files/Makefile.sp
+++ b/sp-files/Makefile.sp
@@ -7,7 +7,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXDIR     = .sphinx
-SPHINXOPTS    ?= -c . -d $(SPHINXDIR)/.doctrees
+SPHINXOPTS    ?= -c . -d $(SPHINXDIR)/.doctrees -j auto
 SPHINXBUILD   ?= $(VENVDIR)/bin/sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
This reverts commit 75412db9be3664171dc3f8365d0c7a7be95137b2.

https://github.com/canonical/canonical-sphinx/issues/27 should be fixed now (with https://github.com/canonical/canonical-sphinx/pull/43).