### PR TITLE
Adds project specific excludes to the make entrypoint

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,1 @@
+# Leave a blank line at the end of this file to support concatenation 

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,5 +1,6 @@
 # This wordlist is from the Sphinx starter pack and should not be
 # modified. Add any custom terms to .custom_wordlist.txt instead.
+# Leave a blank line at the end to support concatenation. 
 
 addons
 API

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -110,13 +110,13 @@ sp-vale: sp-install
 	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/vale || pip install vale
 	@. $(VENV); test -f $(SPHINXDIR)/vale.ini || python3 $(SPHINXDIR)/get_vale_conf.py
 	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(SPHINXDIR)/vale.ini" $(TARGET) > /dev/null \;
-	@cat .sphinx/styles/config/vocabularies/Canonical/accept.txt > .sphinx/styles/config/vocabularies/Canonical/accept_backup.txt
-	@cat .wordlist.txt .custom_wordlist.txt >> .sphinx/styles/config/vocabularies/Canonical/accept.txt
+	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
+	@cat $(SOURCEDIR).wordlist.txt .custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
 	@echo ""
 	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
 	@echo ""
 	@. $(VENV); vale --config "$(SPHINXDIR)/vale.ini" --glob='*.{md,txt,rst}' $(TARGET) || true
-	@cat .sphinx/styles/config/vocabularies/Canonical/accept_backup.txt > .sphinx/styles/config/vocabularies/Canonical/accept.txt && rm .sphinx/styles/config/vocabularies/Canonical/accept_backup.txt
+	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt && rm $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
 
 sp-pdf-prep: sp-install
 	@for packageName in $(REQPDFPACKS); do (dpkg-query -W -f='$${Status}' $$packageName 2>/dev/null | \

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -111,7 +111,7 @@ sp-vale: sp-install
 	@. $(VENV); test -f $(SPHINXDIR)/vale.ini || python3 $(SPHINXDIR)/get_vale_conf.py
 	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(SPHINXDIR)/vale.ini" $(TARGET) > /dev/null \;
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
-	@cat $(SOURCEDIR)/.wordlist.txt .$(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
+	@cat $(SOURCEDIR)/.wordlist.txt $(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
 	@echo ""
 	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
 	@echo ""

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -111,7 +111,7 @@ sp-vale: sp-install
 	@. $(VENV); test -f $(SPHINXDIR)/vale.ini || python3 $(SPHINXDIR)/get_vale_conf.py
 	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(SPHINXDIR)/vale.ini" $(TARGET) > /dev/null \;
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
-	@cat $(SOURCEDIR)/.wordlist.txt .custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
+	@cat $(SOURCEDIR)/.wordlist.txt .$(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
 	@echo ""
 	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
 	@echo ""

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -111,7 +111,7 @@ sp-vale: sp-install
 	@. $(VENV); test -f $(SPHINXDIR)/vale.ini || python3 $(SPHINXDIR)/get_vale_conf.py
 	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(SPHINXDIR)/vale.ini" $(TARGET) > /dev/null \;
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
-	@cat $(SOURCEDIR).wordlist.txt .custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
+	@cat $(SOURCEDIR)/.wordlist.txt .custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
 	@echo ""
 	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
 	@echo ""

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -110,10 +110,13 @@ sp-vale: sp-install
 	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/vale || pip install vale
 	@. $(VENV); test -f $(SPHINXDIR)/vale.ini || python3 $(SPHINXDIR)/get_vale_conf.py
 	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(SPHINXDIR)/vale.ini" $(TARGET) > /dev/null \;
+	@cat .sphinx/styles/config/vocabularies/Canonical/accept.txt > .sphinx/styles/config/vocabularies/Canonical/accept_backup.txt
+	@cat .wordlist.txt .custom_wordlist.txt >> .sphinx/styles/config/vocabularies/Canonical/accept.txt
 	@echo ""
 	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
 	@echo ""
-	@. $(VENV); vale --config "$(SPHINXDIR)/vale.ini" --glob='*.{md,txt,rst}' $(TARGET)
+	@. $(VENV); vale --config "$(SPHINXDIR)/vale.ini" --glob='*.{md,txt,rst}' $(TARGET) || true
+	@cat .sphinx/styles/config/vocabularies/Canonical/accept_backup.txt > .sphinx/styles/config/vocabularies/Canonical/accept.txt && rm .sphinx/styles/config/vocabularies/Canonical/accept_backup.txt
 
 sp-pdf-prep: sp-install
 	@for packageName in $(REQPDFPACKS); do (dpkg-query -W -f='$${Status}' $$packageName 2>/dev/null | \


### PR DESCRIPTION
Some similar work will need to be done when the vale action is done by GitHub actions, but this works for now. I attempted some more complicated logic, but limitations with make brought me back to this relatively basic approach.