### PR TITLE
User selects docs filetype

### DIFF
--- a/.github/workflows/test-starter-pack.yml
+++ b/.github/workflows/test-starter-pack.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Run init and build
+        env:
+          default_filetype_choice: md # don't prompt for user choice
         run: sp-tests/run-init-and-build.sh
       - name: Add some files, build, and test
         run: sp-tests/add-files-and-build.sh
@@ -46,6 +48,8 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Run init and build
+        env:
+          default_filetype_choice: md # don't prompt for user choice
         run: sp-tests/run-init-and-build.sh docs
       - name: Add some files, build, and test
         run: sp-tests/add-files-and-build.sh docs

--- a/init.sh
+++ b/init.sh
@@ -33,7 +33,7 @@ while true; do
 done
 }
 
-# If variable filetype choice is defined in CI then don't prompt user for choice
+# If default variable for filetype choice is defined in CI then don't prompt user for choice
 if [ -z "${default_filetype_choice:-}" ]; then
     promptForFileChoice
 else

--- a/init.sh
+++ b/init.sh
@@ -111,14 +111,15 @@ echo "Copying contents to the installation directory..."
 cp -R "$temp_directory"/sp-files/* "$temp_directory"/sp-files/.??* "$install_directory"
 
 # Delete files with unpreferred filetype in the installation directory
+# No wildcard delete to avoid data loss if user Git-inits in dir with pre-existing files
 if [ -z "${default_filetype_choice:-}" ]; then
     echo "Default filetype not defined, so proceed with deleting unpreferred filetype."
     if [ "$file_type" = 'md' ]; then
-        echo "Deleting rst files..."
+        echo "Deleting .rst files..."
         rm "$install_directory"/doc-cheat-sheet.rst
         rm "$install_directory"/index.rst
     else
-        echo "Deleting md files..."
+        echo "Deleting .md files..."
         rm "$install_directory"/doc-cheat-sheet-myst.md
         rm "$install_directory"/index.md
     fi

--- a/sp-files/index.md
+++ b/sp-files/index.md
@@ -1,0 +1,73 @@
+# Starter pack
+
+**A single sentence that says what the product is, succinctly and memorably.**
+Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+dolore magna aliqua.
+
+**A paragraph of one to three short sentences, that describe what the product
+does.** Urna cursus eget nunc scelerisque viverra mauris in. Nibh mauris
+cursus mattis molestie a iaculis at vestibulum rhoncus est pellentesque
+elit. Diam phasellus vestibulum lorem sed.
+
+**A third paragraph of similar length, this time explaining what need the
+product meets.** Dui ut ornare lectus sit amet est. Nunc sed augue lacus
+viverra vitae congue eu consequat ac libero id faucibus nisl tincidunt eget
+nullam.
+
+**Finally, a paragraph that describes whom the product is useful for.** Nunc
+non blandit massa enim nec dui nunc mattis enim. Ornare arcu odio ut sem
+nulla pharetra diam porttitor leo a diam sollicitudin tempor id eu. Ipsum
+dolor sit amet consectetur adipiscing elit pellentesque habitant.
+
+---------
+
+## In this documentation
+
+````{grid} 1 1 2 2
+
+```{grid-item-card} [Tutorials](index)
+
+**Start here**: a hands-on introduction to Example Product for new users
+```
+
+```{grid-item-card} [How-to guides](index)
+
+**Step-by-step guides** covering key operations and common tasks
+```
+
+````
+
+````{grid} 1 1 2 2
+:reverse:
+
+```{grid-item-card} [Reference](index)
+
+**Technical information** - specifications, APIs, architecture
+```
+
+```{grid-item-card} [Explanations](index)
+
+**Discussion and clarification** of key topics
+```
+
+````
+
+---------
+
+## Project and community
+
+Example Project is a member of the Ubuntu family. It’s an open source project that warmly welcomes community projects, contributions, suggestions, fixes and constructive feedback.
+
+* Code of conduct
+* Get support
+* Join our online chat
+* Contribute
+* Roadmap
+* Thinking about using Example Product for your next project? Get in touch!
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+self
+```


### PR DESCRIPTION
Adds a check to `init.sh` that determines whether the user wants to use `.md` or `.rst` files for their documentation.

If the user chooses one filetype the files of the other type will be removed from the target directory where the documentation is built (namely: the appropriate index file and cheat-sheet file).

The user input is validated and must be either `md` or `rst`.
If the user hits **ENTER** without specifying a filetype then it defaults to `rst`.

To make this work an `index.md` corresponding to the extant `index.rst` was added to the repo.

An env var was added to the starter-pack testsuite to prevent the interactive prompt running during testing.

DOCPR-836
