### PR TITLE
fix: test operations

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -112,7 +112,7 @@ fi
 echo "Copying contents to the installation directory..."
 cp -R "$temp_directory"/sp-files/* "$temp_directory"/sp-files/.??* "$install_directory"
 
-# Delete files not of preferred filetype in the installation directory, rst oreferred default
+# Delete files not of preferred filetype in the installation directory, rst preferred default
 # No wildcard delete to avoid data loss if user Git-inits in dir with pre-existing files
 if [ "$file_type" = 'md' ]; then
     echo "Deleting .rst files..."

--- a/init.sh
+++ b/init.sh
@@ -112,21 +112,16 @@ fi
 echo "Copying contents to the installation directory..."
 cp -R "$temp_directory"/sp-files/* "$temp_directory"/sp-files/.??* "$install_directory"
 
-# Delete files with unpreferred filetype in the installation directory
+# Delete files not of preferred filetype in the installation directory, rst oreferred default
 # No wildcard delete to avoid data loss if user Git-inits in dir with pre-existing files
-if [ -z "${default_filetype_choice:-}" ]; then
-    echo "Default filetype not defined, so proceed with deleting unpreferred filetype."
-    if [ "$file_type" = 'md' ]; then
-        echo "Deleting .rst files..."
-        rm "$install_directory"/doc-cheat-sheet.rst
-        rm "$install_directory"/index.rst
-    else
-        echo "Deleting .md files..."
-        rm "$install_directory"/doc-cheat-sheet-myst.md
-        rm "$install_directory"/index.md
-    fi
+if [ "$file_type" = 'md' ]; then
+    echo "Deleting .rst files..."
+    rm "$install_directory"/doc-cheat-sheet.rst
+    rm "$install_directory"/index.rst
 else
-    echo "Default filetype is defined, so skip filetype deletion."
+    echo "Deleting .md files..."
+    rm "$install_directory"/doc-cheat-sheet-myst.md
+    rm "$install_directory"/index.md
 fi
 
 # Ensure GitHub workflows and woke config are placed in the repo root

--- a/sp-files/.gitignore
+++ b/sp-files/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 .vscode/
 .sphinx/styles/*
 .sphinx/vale.ini
+sp-docs/_build

--- a/sp-files/.sphinx/requirements.txt
+++ b/sp-files/.sphinx/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/canonical/canonical-sphinx@main#egg=canonical-sphinx
+canonical-sphinx[full] @ git+https://github.com/canonical/canonical-sphinx@main
 sphinx-autobuild


### PR DESCRIPTION
Previous dependency declaration format is functional, but egg fragments are not recommended for anything [save for the bare project name](https://pip.pypa.io/en/stable/topics/vcs-support/#url-fragments). Now that canonical-sphinx has changed to provide a minimal install and the full version requires the `[full]` option, this change is required.

Fix init script logic. If init script is run, it is assumed to be a new repository - and there will always be RST and MD index files. This causes a conflict.

Adds ignores for new default build directory.