### PR TITLE
Use pa11y-ci instead of pa11y

### DIFF
--- a/.sphinx/pa11y-ci.json
+++ b/.sphinx/pa11y-ci.json
@@ -1,0 +1,11 @@
+{
+  "defaults": {
+    "chromeLaunchConfig": {
+      "args": [
+        "--no-sandbox"
+      ]
+    }
+  },
+  "reporter": "cli",
+  "standard": "WCAG2AA"
+}

--- a/.sphinx/pa11y.json
+++ b/.sphinx/pa11y.json
@@ -1,9 +1,0 @@
-{
-  "chromeLaunchConfig": {
-    "args": [
-      "--no-sandbox"
-    ]
-  },
-  "reporter": "cli",
-  "standard": "WCAG2AA"
-}

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -20,9 +20,9 @@ ALLFILES      =  *.rst **/*.rst
 ADDPREREQS    ?=
 REQPDFPACKS   = latexmk fonts-freefont-otf texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-lang-cjk texlive-xetex plantuml xindy tex-gyre dvipng
 
-.PHONY: sp-full-help sp-woke-install sp-pa11y-ci-install sp-install sp-run sp-html \
+.PHONY: sp-full-help sp-woke-install sp-pa11y-install sp-install sp-run sp-html \
         sp-epub sp-serve sp-clean sp-clean-doc sp-spelling sp-spellcheck sp-linkcheck sp-woke \
-        sp-allmetrics sp-pa11y-ci sp-pdf-prep-force sp-pdf-prep sp-pdf Makefile.sp sp-vale sp-bash
+        sp-allmetrics sp-pa11y sp-pdf-prep-force sp-pdf-prep sp-pdf Makefile.sp sp-vale sp-bash
 
 sp-full-help: $(VENVDIR)
 	@. $(VENV); $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -104,7 +104,7 @@ sp-woke: sp-woke-install
 	woke $(ALLFILES) --exit-1-on-failure \
 	    -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
-sp-pa11y: sp-pa11y-ci-install sp-html
+sp-pa11y: sp-pa11y-install sp-html
 	$(PA11YCI) $(shell find $(BUILDDIR) -name *.html)
 
 sp-vale: sp-install

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -13,16 +13,16 @@ SOURCEDIR     = .
 METRICSDIR    = $(SOURCEDIR)/metrics
 BUILDDIR      = _build
 VENVDIR       = $(SPHINXDIR)/venv
-PA11Y         = $(SPHINXDIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINXDIR)/pa11y.json
+PA11YCI       = $(SPHINXDIR)/node_modules/pa11y-ci/bin/pa11y-ci.js --config $(SPHINXDIR)/pa11y-ci.json
 VENV          = $(VENVDIR)/bin/activate
 TARGET        = *
 ALLFILES      =  *.rst **/*.rst
 ADDPREREQS    ?=
 REQPDFPACKS   = latexmk fonts-freefont-otf texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-lang-cjk texlive-xetex plantuml xindy tex-gyre dvipng
 
-.PHONY: sp-full-help sp-woke-install sp-pa11y-install sp-install sp-run sp-html \
+.PHONY: sp-full-help sp-woke-install sp-pa11y-ci-install sp-install sp-run sp-html \
         sp-epub sp-serve sp-clean sp-clean-doc sp-spelling sp-spellcheck sp-linkcheck sp-woke \
-        sp-allmetrics sp-pa11y sp-pdf-prep-force sp-pdf-prep sp-pdf Makefile.sp sp-vale sp-bash
+        sp-allmetrics sp-pa11y-ci sp-pdf-prep-force sp-pdf-prep sp-pdf Makefile.sp sp-vale sp-bash
 
 sp-full-help: $(VENVDIR)
 	@. $(VENV); $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -57,11 +57,11 @@ sp-woke-install:
 	@type woke >/dev/null 2>&1 || \
             { echo "Installing \"woke\" snap... \n"; sudo snap install woke; }
 
-sp-pa11y-install:
-	@type $(PA11Y) >/dev/null 2>&1 || { \
-			echo "Installing \"pa11y\" from npm... \n"; \
+sp-pa11y-ci-install:
+	@type $(PA11YCI) >/dev/null 2>&1 || { \
+			echo "Installing \"pa11y-ci\" from npm... \n"; \
 			mkdir -p $(SPHINXDIR)/node_modules/ ; \
-			npm install --prefix $(SPHINXDIR) pa11y; \
+			npm install --prefix $(SPHINXDIR) pa11y-ci; \
 		}
 
 sp-install: $(VENVDIR)
@@ -104,8 +104,8 @@ sp-woke: sp-woke-install
 	woke $(ALLFILES) --exit-1-on-failure \
 	    -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
-sp-pa11y: sp-pa11y-install sp-html
-	find $(BUILDDIR) -name *.html -print0 | xargs -n 1 -0 $(PA11Y)
+sp-pa11y-ci: sp-pa11y-ci-install sp-html
+	$(PA11YCI) $(shell find $(BUILDDIR) -name *.html)
 
 sp-vale: sp-install
 	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/vale || pip install vale

--- a/Makefile.sp
+++ b/Makefile.sp
@@ -57,7 +57,7 @@ sp-woke-install:
 	@type woke >/dev/null 2>&1 || \
             { echo "Installing \"woke\" snap... \n"; sudo snap install woke; }
 
-sp-pa11y-ci-install:
+sp-pa11y-install:
 	@type $(PA11YCI) >/dev/null 2>&1 || { \
 			echo "Installing \"pa11y-ci\" from npm... \n"; \
 			mkdir -p $(SPHINXDIR)/node_modules/ ; \
@@ -104,7 +104,7 @@ sp-woke: sp-woke-install
 	woke $(ALLFILES) --exit-1-on-failure \
 	    -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
-sp-pa11y-ci: sp-pa11y-ci-install sp-html
+sp-pa11y: sp-pa11y-ci-install sp-html
 	$(PA11YCI) $(shell find $(BUILDDIR) -name *.html)
 
 sp-vale: sp-install


### PR DESCRIPTION
Main improvement: improved readability of logs, as well as "potential" performance improvements due to not having to launch `pa11y` for each file. In addition, `pa11y-ci` offers a concurrency option, but that seems to be broken at the moment.

`pa11y` output:
```

Welcome to Pa11y

 > Running Pa11y on URL file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/404/index.html

No issues found!


Welcome to Pa11y

 > Running Pa11y on URL file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/search/index.html

No issues found!


Welcome to Pa11y

 > Running Pa11y on URL file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/tutorial/index.html

Results for URL: file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/tutorial/index.html

 • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 3.31:1. Recommendation:  change text colour to #f9fcff.
   ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
   ├── #installing-mir-on-debian > p > a
   └── <a class="reference external" href="https://tracker.debian.org/pkg/...">https://tracker.debian.org/pkg/mir</a>
```

`pa11y-ci` output:
```
Running Pa11y on 26 URLs:
 > file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/404/index.html - 0 errors
 > file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/search/index.html - 0 errors
 > file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/tutorial/index.html - 0 errors
 > file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/genindex/index.html - 0 errors
 > file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/reference/continuous-integration/index.html - 0 errors
 > file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/reference/kernel_requirements/index.html - 0 errors

...

Errors in file:///home/tarek/code-projects/mir/doc/build_doc/doc/sphinx/_build/reference/introducing_the_miral_api/index.html:

 • This element has insufficient contrast at this conformance level. Expected a
   contrast ratio of at least 4.5:1, but text in this element has a contrast
   ratio of 3.84:1. Recommendation:  change text colour to #bb5400.

   (#codecell0 > span:nth-child(82))

   <span class="o">::</span>

 • This element has insufficient contrast at this conformance level. Expected a
   contrast ratio of at least 4.5:1, but text in this element has a contrast
   ratio of 3.84:1. Recommendation:  change text colour to #bb5400.

   (#codecell0 > span:nth-child(101))

   <span class="o">=</span>
```
