### PR TITLE
Update instructions for sequential navigation

### DIFF
--- a/sp-docs/docs/customise.rst
+++ b/sp-docs/docs/customise.rst
@@ -105,6 +105,14 @@ Add page-specific configuration
 You can override some global configuration for specific pages.
 
 For example, you can configure whether to display Previous/Next buttons at the bottom of pages by setting the ``sequential_nav`` variable in the :file:`conf.py` file.
+
+.. code:: python
+
+   html_context = {
+       ...
+       "sequential_nav": "both"
+   }
+
 You can then override this default setting for a specific page (for example, to turn off the Previous/Next buttons by default, but display them in a multi-page tutorial).
 
 To do so, add `file-wide metadata`_ at the top of a page.

--- a/sp-files/conf.py
+++ b/sp-files/conf.py
@@ -142,6 +142,10 @@ html_context = {
     #
     # TODO: To customise the directory, uncomment and update as needed.
     "github_folder": "/sp-docs/",
+
+    # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
+    # Valid options: none, prev, next, both
+    # "sequential_nav": "both",
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897


### PR DESCRIPTION
The settings used to be part of `conf.py`.
Not sure if that was intentionally removed but it took me a bit of time to figure out where it should go.