### PR TITLE
Update sphinx-python-dependency-build-checks.yml

### DIFF
--- a/sp-files/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/sp-files/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -39,6 +39,7 @@ jobs:
             python3-venv \
             rustc
       - name: Build Sphinx venv
+        working-directory: "docs"
         run: |
           set -ex
           make -f Makefile.sp \


### PR DESCRIPTION
Without specifying the working directory, the GitHub Action will fail to run.