### PR TITLE
Removed dependency check workflow from init script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -60,7 +60,6 @@ sed -i "s|configuration:\s*sp-docs/conf\.py|configuration: $install_directory/co
 sed -i "s|requirements:\s*sp-docs/\.sphinx/requirements\.txt|requirements: $install_directory/.sphinx/requirements.txt|g" "$temp_directory/sp-files/.readthedocs.yaml"
 echo "Updating contribution guide..."
 sed -i "s|DOCDIR|$install_directory|g" "$temp_directory/sp-files/contributing.rst"
-[ "$install_directory" != "." ] && sed -i "s/Makefile.sp/$install_directory\/Makefile.sp/" "$temp_directory/sp-files/.github/workflows/sphinx-python-dependency-build-checks.yml"
 [ "$install_directory" != "." ] && sed -i "s/.sphinx\/.markdownlint.json/$install_directory\/.sphinx\/.markdownlint.json/" "$temp_directory/sp-files/.github/workflows/markdown-style-checks.yml"
 
 # Update the GitHub folder path in the configuration file

--- a/sp-docs/.custom_wordlist.txt
+++ b/sp-docs/.custom_wordlist.txt
@@ -14,3 +14,5 @@ lang
 cjk
 xetex
 xindy
+yml
+github

--- a/sp-docs/docs/automatic_checks_sphinxbuilddepdencies.rst
+++ b/sp-docs/docs/automatic_checks_sphinxbuilddepdencies.rst
@@ -1,0 +1,25 @@
+.. _automatic-checks-sphinxbuilddependencies:
+
+Sphinx environment build dependencies
+=====================================
+
+The `Sphinx environment build dependencies check`_ is a GitHub Actions workflow
+that ensures all the build dependencies required for a Sphinx virtual
+environment are correctly documented and can be successfully built from source.
+
+This is crucial for projects that integrate documentation generation into their
+build artefacts, especially when built on various target architectures where
+pre-built Python packages may not be available.
+
+Run the Python build dependencies check
+---------------------------------------
+
+To use this GitHub Action workflow, copy the
+`sphinx-python-dependency-build-checks.yml`_ file into the `.github/workflows`
+directory of your documentation repository, and commit the changes.
+
+The workflow will be triggered for any ``push`` or ``pull_request`` events to
+your repository, or be triggered manually.
+
+.. _Sphinx environment build dependencies check: https://github.com/canonical/sphinx-docs-starter-pack/blob/main/sp-files/.github/workflows/sphinx-python-dependency-build-checks.yml
+.. _sphinx-python-dependency-build-checks.yml: https://github.com/canonical/sphinx-docs-starter-pack/blob/main/sp-files/.github/workflows/sphinx-python-dependency-build-checks.yml


### PR DESCRIPTION
Hi @SecondSkoll ,

I removed the Sphinx dependencies check from being copied during the repository initialisation with `init.sh` and created a page for it so users will still be able to run / use the workflow as needed.