### PR TITLE
Added check of NPM files' permissions

### DIFF
--- a/sp-files/.sphinx/check_npmdir_ownership.sh
+++ b/sp-files/.sphinx/check_npmdir_ownership.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Some builds give a permission problem that $HOME/.npm is owned by root.
+# This script rectifies that and sets $HOME/.npm to the current user
+# See https://stackoverflow.com/questions/59437833/error-your-cache-folder-contains-root-owned-files-due-to-a-bug-in-previous-ver
+#
+
+dir=$HOME/.npm
+
+#Check if directory exists
+if [ ! -d "$dir" ]; then
+    exit 0
+fi
+
+owner=`stat -c "%U" $dir`
+
+if [ "$owner" = "$USER" ]; then
+    exit 0
+fi
+
+echo "Changing user of $dir to $USER"
+sudo chown -R $USER $dir
+

--- a/sp-files/Makefile.sp
+++ b/sp-files/Makefile.sp
@@ -77,6 +77,7 @@ sp-pa11y-install:
 	@type $(PA11Y) >/dev/null 2>&1 || { \
 			echo "Installing \"pa11y\" from npm... \n"; \
 			mkdir -p $(SPHINXDIR)/node_modules/ ; \
+			$(SPHINXDIR)/check_npmdir_ownership.sh ; \
 			npm install --prefix $(SPHINXDIR) pa11y; \
 		}
 


### PR DESCRIPTION
When testing to build documentation on self-hosted runner I ran into constant failures like this:

` Installing "pa11y" from npm... 

npm WARN using --force Recommended protections disabled.
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /home/ubuntu/.npm/_cacache
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1000:1000 "/home/ubuntu/.npm"

npm ERR! Log files were not written due to an error writing to the directory: /home/ubuntu/.npm/_logs
npm ERR! You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
make: *** [Makefile:56: pa11y-install] Error 243
Command 'make -f Makefile pa11y' returned non-zero exit status 2.`

See https://github.com/canonical/information-systems-documentation/actions/runs/11981830073/job/33408782114#step:8:44

In order to rectify it, one has to change the owner of the .npm directory. The command suggested in the error message may work on the build server, but it will fail locally as the owner is not necessary 'ubuntu'. The script does the change locally and is called on 'make pa11y-install'.

I have tested in a this template. I have also tested the solution in information-systems-documentation repo.