### PR TITLE
doc: Update broken link

### DIFF
--- a/sp-docs/docs/rtd.rst
+++ b/sp-docs/docs/rtd.rst
@@ -3,7 +3,7 @@
 Set up Read the Docs
 ====================
 
-For Canonical-specific information on how to set up your documentation on Read the Docs, see the `Read the Docs at Canonical <https://library.canonical.com/documentation/read-the-docs>`_ and `How to publish documentation on Read the Docs <https://library.canonical.com/documentation/read-the-docs-at-canonical>`_ guides.
+For Canonical-specific information on how to set up your documentation on Read the Docs, see the `Read the Docs at Canonical <https://library.canonical.com/documentation/read-the-docs-at-canonical>`_ and `How to publish documentation on Read the Docs <https://library.canonical.com/documentation/publish-on-read-the-docs>`_ guides.
 
 In general, after enabling the starter pack for your documentation, follow these steps to build and publish your documentation on Read the Docs:
 

--- a/sp-docs/docs/rtd.rst
+++ b/sp-docs/docs/rtd.rst
@@ -3,7 +3,7 @@
 Set up Read the Docs
 ====================
 
-For Canonical-specific information on how to set up your documentation on Read the Docs, see the `Read the Docs at Canonical <https://library.canonical.com/documentation/read-the-docs>`_ and `How to publish documentation on Read the Docs <https://library.canonical.com/documentation/publish-on-read-the-docs>`_ guides.
+For Canonical-specific information on how to set up your documentation on Read the Docs, see the `Read the Docs at Canonical <https://library.canonical.com/documentation/read-the-docs>`_ and `How to publish documentation on Read the Docs <https://library.canonical.com/documentation/read-the-docs-at-canonical>`_ guides.
 
 In general, after enabling the starter pack for your documentation, follow these steps to build and publish your documentation on Read the Docs:
 

--- a/sp-docs/reuse/links.txt
+++ b/sp-docs/reuse/links.txt
@@ -1,6 +1,6 @@
 .. _reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _MyST style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/
-.. _Read the Docs at Canonical: https://library.canonical.com/documentation/read-the-docs
+.. _Read the Docs at Canonical: https://library.canonical.com/documentation/read-the-docs-at-canonical
 .. _How to publish documentation on Read the Docs: https://library.canonical.com/documentation/publish-on-read-the-docs
 .. _Example product documentation: https://canonical-example-product-documentation.readthedocs-hosted.com/
 .. wokeignore:rule=master


### PR DESCRIPTION
The RTD at Canonical link was 404-ing, so I corrected it