### PR TITLE
Add smarter defaults for linkcheck.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,6 +195,9 @@ linkcheck_ignore = [
 
 linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]
 
+# give linkcheck multiple tries on failure
+# linkcheck_timeout = 30
+linkcheck_retries = 3
 
 ########################
 # Configuration extras #


### PR DESCRIPTION
This includes a default of 3 retires on failure and then makes the timeout option more visible within the config file.

These are based on a fixing change to [MicroOVN](https://github.com/canonical/microovn/pull/207) where we were having instability in linkchecks.