### PR TITLE
fix: prevent repeated CI runs

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -10,10 +10,12 @@
 # available, and as such we need to make sure building wheels from source can
 # succeed.
 name: Sphinx python dependency build checks
+
 on:
-- push
-- pull_request
-- workflow_dispatch
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch: # manual trigger
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-starter-pack.yml
+++ b/.github/workflows/test-starter-pack.yml
@@ -4,8 +4,9 @@
 name: Test starter pack
 
 on:
-- pull_request
-- push
+  push:
+    branches: [ main ]
+  pull_request:
 
 jobs:
   test-docs:


### PR DESCRIPTION
These workflows run twice on PRs because the trigger for push events isn't restricted to main:

![image](https://github.com/user-attachments/assets/9934a785-3c89-4883-9578-2d0e8e4319cc)

How to reproduce:

1. Open PR (this runs the checks once)
2. Push another commit (this will run the checks twice, for the `push` event & `pull_request`)

Similar to #267