### PR TITLE
Feat: trigger readthedocs build only upon doc changes

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    paths:
+      - 'docs/**'   # Only run on changes to the docs directory
 
   workflow_dispatch:
     # Manual trigger

--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
     - main
+    paths:
+    - 'docs/**'   # Only run on changes to the docs directory
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'docs/**'   # Only run on changes to the docs directory
 
 jobs:
   markdown-lint:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,16 @@ build:
   jobs:
     pre_install:
     - git fetch --unshallow || true
+    post_checkout:
+    # Cancel building pull requests when there aren't changed in the docs directory.
+    # If there are no changes (git diff exits with 0) we force the command to return with 183.
+    # This is a special exit code on Read the Docs that will cancel the build immediately.
+    # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+    - |
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'docs/' '.readthedocs.yaml';
+      then
+        exit 183;
+      fi
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/.sphinx/.pre-commit-config.yaml
+++ b/docs/.sphinx/.pre-commit-config.yaml
@@ -6,15 +6,18 @@ repos:
         entry: make -C docs spelling
         language: system
         pass_filenames: false
+        files: ^docs/.*\.(rst|md|txt)$
 
       - id: make-linkcheck
         name: Run make linkcheck
         entry: make -C docs linkcheck
         language: system
         pass_filenames: false
+        files: ^docs/.*\.(rst|md|txt)$
 
       - id: make-woke
         name: Run make woke
         entry: make -C docs woke
         language: system
         pass_filenames: false
+        files: ^docs/.*\.(rst|md|txt)$

--- a/docs/content/automatic_checks.rst
+++ b/docs/content/automatic_checks.rst
@@ -54,3 +54,18 @@ may not be able to use. You may select your own runners with an override, see li
          fetch-depth: 0
          runs-on: "ubuntu-22.04"
 
+Workflow triggers
+-----------------
+
+For efficiency, the documentation check workflows are configured to run **only** when
+changes are made to files in the ``docs/`` directory. If your project is structured
+differently, or if you want to run the checks on other directories, modify the trigger
+paths in the workflow files:
+
+.. code-block:: yaml
+   :emphasize-lines: 4
+   
+   on:
+     pull_request:
+       paths:
+         - 'docs/**'   # Only run on changes to the docs directory

--- a/docs/content/rtd.rst
+++ b/docs/content/rtd.rst
@@ -14,6 +14,11 @@ In general, after enabling the starter pack for your documentation, follow these
    To do this, navigate to :guilabel:`Admin` > :guilabel:`Settings` and specify the path under "Path for ``.readthedocs.yaml``".
    
    For example, if your documentation folder is :file:`docs/`, specify the path as ``docs/.readthedocs.yaml``.
+#. Update the relative paths in the :file:`.readthedocs.yaml` file to match the structure of your project. You might need to update the file paths specified in the following fields:
+
+   * ``job.post_checkout``
+   * ``sphinx.configuration``
+   * ``python.install.requirements``
 
 After this initial setup, your documentation should build successfully if your project is hosted from a public repository.
 If you get any errors, check the build log for indications on what the problem is.


### PR DESCRIPTION
(Resolves [DOCPR-1420](https://warthogs.atlassian.net/browse/DOCPR-1420))

The Readthedocs build checks on pull requests should only be triggered when documentation changes are included. This prevents extra builds in repositories that contain both the source code and docs.

A triggering condition is introduced to `.readthedocs.yml` template to cancel build upon `git diff` result.  [Readthedocs documentation](https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition) added as comment

[DOCPR-1420]: https://warthogs.atlassian.net/browse/DOCPR-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ