### PR TITLE
fix: Vale operations

### DIFF
--- a/docs/.sphinx/get_vale_conf.py
+++ b/docs/.sphinx/get_vale_conf.py
@@ -5,7 +5,6 @@ import os
 
 DIR = os.getcwd()
 
-
 def main():
     if os.path.exists(f"{DIR}/.sphinx/styles/Canonical"):
         print("Vale directory exists")
@@ -20,6 +19,22 @@ def main():
     for item in r.json():
         download = requests.get(item["download_url"])
         file = open(".sphinx/styles/Canonical/" + item["name"], "w")
+        file.write(download.text)
+        file.close()
+
+    # Update dictionary
+    if os.path.exists(f"{DIR}/.sphinx/styles/config/dictionaries"):
+        print("Dictionary directory exists")
+    else:
+        os.makedirs(f"{DIR}/.sphinx/styles/config/dictionaries")
+    url = (
+        "https://api.github.com/repos/canonical/praecepta/"
+        + "contents/styles/config/dictionaries"
+    )
+    r = requests.get(url)
+    for item in r.json():
+        download = requests.get(item["download_url"])
+        file = open(".sphinx/styles/config/dictionaries/" + item["name"], "w")
         file.write(download.text)
         file.close()
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -126,7 +126,8 @@ vale-install: install
 	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/vale || pip install rst2html vale
 	@. $(VENV); test -f $(VALE_CONFIG) || python3 $(SPHINXDIR)/get_vale_conf.py
 	@printf '.Name=="Canonical.400-Enforce-inclusive-terms"' > $(SPHINXDIR)/styles/woke.filter
-	@printf '.Level=="error"' > $(SPHINXDIR)/styles/error.filter
+	@printf '.Level=="error" and .Name!="Canonical.500-Repeated-words" and .Name!="Canonical.000-US-spellcheck"' > $(SPHINXDIR)/styles/error.filter
+	@printf '.Name=="Canonical.000-US-spellcheck"' > $(SPHINXDIR)/styles/spelling.filter
 	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(VALE_CONFIG)" $(TARGET) > /dev/null \;
 
 woke: vale-install
@@ -141,6 +142,13 @@ vale: vale-install
 	@cat $(SPHINXDIR)/.wordlist.txt $(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
 	@printf "Running Vale against $(TARGET). To change target set TARGET= with make command\n"
 	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/error.filter' --glob='*.{md,rst}' $(TARGET) || true
+	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt && rm $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
+
+vale-spelling: vale-install
+	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
+	@cat $(SPHINXDIR)/.wordlist.txt $(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
+	@printf "Running Vale against $(TARGET). To change target set TARGET= with make command\n"
+	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/spelling.filter' --glob='*.{md,rst}' $(TARGET) || true
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt && rm $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
 
 pdf-prep: install


### PR DESCRIPTION
Current script does not obtain newly included dictionaries. Adds section to `docs/.sphinx/get_vale_conf.py` to obtain relevant files.

Changes filters used in Makefile's `vale-install` to provide separate style guide, inclusive language, and spelling check functions.

Provides a spelling function for testing and validation before replacing pyspelling.