### PR TITLE
docs: add info about connecting GitHub accounts to Read the Docs

### DIFF
--- a/docs/content/rtd.rst
+++ b/docs/content/rtd.rst
@@ -9,6 +9,8 @@ In general, after enabling the starter pack for your documentation, follow these
 
 1. Make sure your documentation :ref:`builds without errors or warnings <build-clean>`.
 #. Log into Read the Docs.
+#. In your account settings, navigate to :guilabel:`Connected services` and check that your GitHub account is listed.
+   If it's not listed, add a connection to GitHub. See `How to connect your Read the Docs account to your Git provider`_.
 #. Use the `manual import`_ to create a project.
 #. Specify the path to the :file:`.readthedocs.yaml` file for your build.
    To do this, navigate to :guilabel:`Admin` > :guilabel:`Settings` and specify the path under "Path for ``.readthedocs.yaml``".
@@ -32,7 +34,10 @@ Configure the webhook
 If you have administrator privileges for the GitHub repository that you are adding, the integration webhook (which is responsible for automatically building the documentation when the repository changes) is created automatically.
 
 If you don't have administrator privileges, the webhook must be set up by someone who does.
-See `How to manually configure a Git repository integration`_ if you want to set it up manually.
+The person with administrator privileges must have connected their Read the Docs account to GitHub.
+See `How to connect your Read the Docs account to your Git provider`_.
+
+See `How to manually configure a Git repository integration`_ if you want to set up the webhook manually.
 
 Make your documentation public
 ------------------------------

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -13,6 +13,7 @@
 .. _change log: https://github.com/canonical/sphinx-docs-starter-pack/wiki/Change-log
 .. _Open Graph: https://ogp.me/
 .. _manual import: https://readthedocs.com/dashboard/import/manual/
+.. _How to connect your Read the Docs account to your Git provider: https://docs.readthedocs.com/platform/stable/guides/connecting-git-account.html
 .. _How to manually configure a Git repository integration: https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _Markdown: https://commonmark.org/


### PR DESCRIPTION
After I imported a new project into Read the Docs and set up the webhook, RTD build status wasn't visible as a check in GitHub. The issue was that the webhook wasn't set up by someone with admin privileges for the GitHub repo. Additionally, the admin first needed to connect their RTD account to GitHub.

This PR makes a couple of additions to [Set up Read the Docs](https://canonical-starter-pack.readthedocs-hosted.com/latest/content/rtd/) to remind people to check that their RTD account is connected to GitHub.