### PR TITLE
chore: doc config changes for canonical-sphinx 0.4.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,13 +135,13 @@ html_context = {
     # Docs branch in the repo; used in links for viewing the source files
     #
     # TODO: To customise the branch, uncomment and update as needed.
-    'github_version': 'main',
+    'repo_default_branch': 'main',
     # Docs location in the repo; used in links for viewing the source files
     #
 
 
     # TODO: To customise the directory, uncomment and update as needed.
-    "github_folder": "/docs/",
+    "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
     # "sequential_nav": "both",
@@ -151,6 +151,12 @@ html_context = {
     # Required for feedback button    
     'github_issues': 'enabled',
 }
+
+# To enable the edit button (pencil icon next to the feedback button)
+#
+# html_theme_options = {
+# 'source_edit_link': 'https://github.com/canonical/sphinx-docs-starter-pack',
+# }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,7 @@ html_context = {
     'github_issues': 'enabled',
 }
 
-# To enable the edit button (pencil icon next to the feedback button)
+# TODO: Uncomment to enable the edit button (pencil icon next to the feedback button)
 #
 # html_theme_options = {
 # 'source_edit_link': 'https://github.com/canonical/sphinx-docs-starter-pack',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,8 @@ html_context = {
     'github_issues': 'enabled',
 }
 
-# TODO: Uncomment to enable the edit button (pencil icon next to the feedback button)
+# TODO: To enable the edit button (pencil icon next to the feedback button),
+#       uncomment and update as needed.
 #
 # html_theme_options = {
 # 'source_edit_link': 'https://github.com/canonical/sphinx-docs-starter-pack',


### PR DESCRIPTION
Adding a placeholder section in `docs/conf.py` for how to enable the edit button (per [Version 0.4.0](https://github.com/canonical/canonical-sphinx/releases/tag/0.4.0) of `canonical-sphinx`).