### PR TITLE
Allow users optionally define which host IP address to bind

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,6 +18,8 @@ METRICSDIR      = $(SOURCEDIR)/.sphinx/metrics
 REQPDFPACKS     = latexmk fonts-freefont-otf texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-lang-cjk texlive-xetex plantuml xindy tex-gyre dvipng
 CONFIRM_SUDO    ?= N
 VALE_CONFIG     = $(SPHINXDIR)/vale.ini
+SPHINX_HOST     ?= 127.0.0.1
+SPHINX_PORT     ?= 0
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -86,10 +88,8 @@ pa11y-install:
 
 install: $(VENVDIR)
 
-SPHINX_HOST ?= 127.0.0.1
-
-run: sp-install
-	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --host $(SPHINX_HOST)
+run: install
+	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_HOST) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 html: install

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -86,8 +86,10 @@ pa11y-install:
 
 install: $(VENVDIR)
 
-run: install
-	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+SPHINX_HOST ?= 127.0.0.1
+
+run: sp-install
+	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --host $(SPHINX_HOST)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 html: install

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -89,7 +89,7 @@ pa11y-install:
 install: $(VENVDIR)
 
 run: install
-	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_HOST) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 html: install

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ REQPDFPACKS     = latexmk fonts-freefont-otf texlive-latex-recommended texlive-l
 CONFIRM_SUDO    ?= N
 VALE_CONFIG     = $(SPHINXDIR)/vale.ini
 SPHINX_HOST     ?= 127.0.0.1
-SPHINX_PORT     ?= 0
+SPHINX_PORT     ?= 8000
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
While the existing config works when the documentation is deployed to production via ReadTheDocs, it presents a new issue for contributors contributing to Canonical repos like the Ubuntu Server and Juju docs.

Personally, I struggled with this issue. I almost gave up on contributing to these repos because I couldn't access the built docs on my browser while also allowing it to automatically make changes as I go. This fix has made me overcome my struggle, and now I have 15 merged PRs across these repos.

Now, not all Canonical repos need this change. I didn't struggle with this when I worked on the Ubuntu cloud docs repo. Regardless, I still think this change will be important. It still retains the previous config which binds to localhost.

Relevant to juju/juju#19143 and canonical/ubuntu-server-documentation#125.