### PR TITLE
Use US spelling in checks

### DIFF
--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -2,7 +2,7 @@ matrix:
   - name: rST files
     aspell:
       lang: en
-      d: en_GB
+      d: en_US
     dictionary:
       wordlists:
         - .sphinx/.wordlist.txt


### PR DESCRIPTION
Per the updated style guide [1], spelling should now be US, not GB

[1]: https://docs.ubuntu.com/styleguide/en#spelling