### PR TITLE
Fix Sphinx python dependency build checks 404 mirror error

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         set -ex
+        sudo apt update
         sudo apt -y install \
           cargo \
           libpython3-dev \


### PR DESCRIPTION
Added a `sudo apt update` before installation to fix a mirror link 404 error during build checks.