### PR TITLE
Update links and references to style guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Substantive file changes relating to starter pack functionality are detailed here.
 
+## 1.0.1
+
+Removed links to canonical-documentation-with-sphinx-and-readthedocscom RTD site and
+replaced with targets in the style guides.
+
+### Changed
+
+* `docs/how-to/contributing.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+* `docs/how-to/guidance.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+* `docs/reference/automatic_checks_spelling.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+* `docs/reference/doc-cheat-sheet-myst.md` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+* `docs/reference/doc-cheat-sheet.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+* `docs/reference/style-guide-myst.md` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+* `docs/reference/style-guide.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+* `docs/reuse/links.txt` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
+
 ## 1.0.0
 
 First versioned release. Adds an update command to better facilitate updates to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,6 @@
 
 Substantive file changes relating to starter pack functionality are detailed here.
 
-## 1.0.1
-
-Removed links to canonical-documentation-with-sphinx-and-readthedocscom RTD site and
-replaced with targets in the style guides.
-
-### Changed
-
-* `docs/how-to/contributing.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-* `docs/how-to/guidance.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-* `docs/reference/automatic_checks_spelling.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-* `docs/reference/doc-cheat-sheet-myst.md` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-* `docs/reference/doc-cheat-sheet.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-* `docs/reference/style-guide-myst.md` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-* `docs/reference/style-guide.rst` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-* `docs/reuse/links.txt` [#368](https://github.com/canonical/sphinx-docs-starter-pack/pull/368)
-
 ## 1.0.0
 
 First versioned release. Adds an update command to better facilitate updates to

--- a/docs/how-to/contributing.rst
+++ b/docs/how-to/contributing.rst
@@ -299,8 +299,8 @@ It is based on the `Canonical starter pack
 and hosted on `Read the Docs <https://about.readthedocs.com/>`_.
 
 For syntax help and guidelines,
-refer to the `Canonical style guides
-<https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/>`_.
+refer to the Canonical style guides
+(:ref:`reStructuredText <style-guide>` and :ref:`MyST <myst_style_guide>`).
 
 In structuring,
 the documentation employs the `Diátaxis <https://diataxis.fr/>`_ approach.

--- a/docs/how-to/guidance.rst
+++ b/docs/how-to/guidance.rst
@@ -11,8 +11,8 @@ For more detailed information and syntax guides, see the linked documents.
 
 To make it easier for you to get started, and to keep our documentation consistent, the following style guides give recommendations and conventions for using |RST| and Markdown/MyST:
 
-- `reStructuredText style guide`_
-- `MyST style guide`_
+- :ref:`reStructuredText style guide <style-guide>`
+- :ref:`MyST style guide <myst_style_guide>`
 
 The starter pack also contains cheat sheets for both markup languages that allow to easily copy and paste the markup that you want.
 See the :file:`doc-cheat-sheet.rst` and :file:`doc-cheat-sheet-myst.md` files.

--- a/docs/reference/automatic_checks_spelling.rst
+++ b/docs/reference/automatic_checks_spelling.rst
@@ -39,4 +39,4 @@ Sometimes, you need to use a term in a specific context that should usually fail
 (For example, you might need to refer to a product called ``ABC Docs``, but you do not want to add ``docs`` to the word list because it isn't a valid word.)
 
 In this case, you can use the ``:spellexception:`` role.
-See `More useful markup`_ in the |RST| style guide (also available in MyST).
+See :ref:`More useful markup <section_more_useful_markup>` in the |RST| style guide (also available in MyST).

--- a/docs/reference/doc-cheat-sheet-myst.md
+++ b/docs/reference/doc-cheat-sheet-myst.md
@@ -19,7 +19,7 @@ myst:
 This file contains the syntax for commonly used Markdown and MyST markup.
 Open it in your text editor to quickly copy and paste the markup you need.
 
-See the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) for detailed information and conventions.
+See the {ref}`MyST style guide <myst_style_guide>` for detailed information and conventions.
 
 Also see the [MyST documentation](https://myst-parser.readthedocs.io/en/latest/index.html) for detailed information on MyST, and the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en) for general style conventions.
 

--- a/docs/reference/doc-cheat-sheet.rst
+++ b/docs/reference/doc-cheat-sheet.rst
@@ -12,7 +12,7 @@ ReStructuredText cheat sheet
 This file contains the syntax for commonly used reST markup.
 Open it in your text editor to quickly copy and paste the markup you need.
 
-See the `reStructuredText style guide <https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/>`_ for detailed information and conventions.
+See the :ref:`reStructuredText style guide <style-guide>` for detailed information and conventions.
 
 Also see the `Sphinx reStructuredText Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ for more details on reST, and the `Canonical Documentation Style Guide <https://docs.ubuntu.com/styleguide/en>`_ for general style conventions.
 

--- a/docs/reference/style-guide-myst.md
+++ b/docs/reference/style-guide-myst.md
@@ -8,6 +8,8 @@ myst:
                        ```"
 ---
 
+(myst_style_guide)=
+
 # MyST style guide
 
 The documentation files use a mixture of [Markdown](https://commonmark.org/) and [MyST](https://myst-parser.readthedocs.io/) syntax.

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -826,6 +826,8 @@ You can define glossary terms in any file. Ideally, all terms should be collecte
    * - ``:term:`an example term```
      - :term:`an example term`
 
+.. _section_more_useful_markup:
+
 More useful markup
 ------------------
 

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -17,16 +17,13 @@
 .. _list tables: https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table
 .. _manual import: https://readthedocs.com/dashboard/import/manual/
 .. _Markdown: https://commonmark.org/
-.. _More useful markup: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/#more-useful-markup
 .. _MyST: https://myst-parser.readthedocs.io/
-.. _MyST style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/
 .. _Open Graph: https://ogp.me/
 .. _Pa11y: https://pa11y.org/
 .. _Pa11y readme: https://github.com/pa11y/pa11y#command-line-configuration
 .. _Pygments documentation: https://pygments.org/languages/
 .. _Read the Docs at Canonical: https://library.canonical.com/documentation/read-the-docs-at-canonical
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
-.. _reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _`Sphinx`: https://www.sphinx-doc.org/
 .. _`Sphinx configuration`: https://www.sphinx-doc.org/en/master/usage/configuration.html
 .. _Sphinx design: https://sphinx-design.readthedocs.io/en/latest/


### PR DESCRIPTION
In preparation for archiving sphinx-docs-guide, I removed any links to the "canonical-documentation-with-sphinx-and-readthedocscom" RTD site and replaced those links with references to the style guides in this repo.

- [x] Have you updated `CHANGELOG.md` with relevant file changes?
- [X] Have you updated the documentation for this change?

-----