### PR TITLE
Add new notes to the style guide and cheat sheet

### DIFF
--- a/docs/reference/doc-cheat-sheet-myst.md
+++ b/docs/reference/doc-cheat-sheet-myst.md
@@ -163,6 +163,14 @@ Important information
 This might damage your hardware!
 ```
 
+```{warning}
+This could damage your hardware!
+```
+
+```{seealso}
+A reference to related content.
+```
+
 ## Images
 
 ![Alt text](https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png)

--- a/docs/reference/doc-cheat-sheet.rst
+++ b/docs/reference/doc-cheat-sheet.rst
@@ -186,6 +186,12 @@ Notes
 .. caution::
    This might damage your hardware!
 
+.. warning::
+   This could damage your hardware!
+
+.. seealso::
+   A reference to related content.
+
 Images
 ------
 

--- a/docs/reference/style-guide-myst.md
+++ b/docs/reference/style-guide-myst.md
@@ -541,8 +541,22 @@ See [list tables](https://docutils.sourceforge.io/docs/ref/rst/directives.html#l
   - ```{caution}
     This might damage your hardware!
     ```
-
-
+* - ````
+    ```{warning}
+    This could damage your hardware!
+    ```
+    ````
+  - ```{warning}
+    This could damage your hardware!
+    ```
+* - ````
+    ```{seealso}
+    A reference to related content.
+    ```
+    ````
+  - ```{seealso}
+    A reference to related content.
+    ```
 `````
 
 Adhere to the following conventions:

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -588,6 +588,18 @@ Notes
              This might damage your hardware!
      - .. caution::
           This might damage your hardware!
+   * - .. code::
+
+          .. warning::
+              This could damage your hardware!
+     - .. warning::
+          This could damage your hardware!
+   * - .. code::
+
+          .. seealso::
+              A reference to related content.
+     - .. seealso::
+          A reference to related content.
 
 Adhere to the following conventions:
 


### PR DESCRIPTION
This PR adds two new notes to the style guide and cheat sheet.

1. warning
2. seealso

These notes are used in the Ubuntu server docs. One example is on this [Samba page](https://documentation.ubuntu.com/server/how-to/samba/provision-samba-ad-controller/).

-----

- [x] Have you updated the documentation for this change?

