### PR TITLE
Add command input and output standard

### DIFF
--- a/docs/reference/style-guide-myst.md
+++ b/docs/reference/style-guide-myst.md
@@ -195,6 +195,58 @@ Output is the main content of the directive.
 To override the prompt (`user@host:~$` by default), specify the `:user:` and/or `:host:` options.
 To make the terminal scroll horizontally instead of wrapping long lines, add `:scroll:`.
 
+### Command input and output
+
+When you are not trying to visually simulate a terminal, separate the input and output code blocks.
+Do not prefix commands with `$` as this is not user-friendly. Users should be able to copy and paste the command without requiring edits.
+
+`````{list-table}
+   :header-rows: 1
+
+* - Type
+  - Markdown/MyST
+  - Rendering
+* - Input
+  - ````
+
+    ```bash
+    docker volume inspect my-vol
+    ```
+
+    ````  
+  - ```bash
+    docker volume inspect my-vol
+    ```
+* - Output
+  - ````
+
+    ```json
+    [
+      {
+        "Driver": "local",
+        "Labels": {},
+        "Mountpoint": "/var/lib/docker/volumes/my-vol/_data",
+        "Name": "my-vol",
+        "Scope": "local"
+      }
+    ]
+    ```
+
+    ````
+  - ```json
+    [
+      {
+        "Driver": "local",
+        "Labels": {},
+        "Mountpoint": "/var/lib/docker/volumes/my-vol/_data",
+        "Name": "my-vol",
+        "Scope": "local"
+      }
+    ]
+    ```
+
+`````
+
 ## Links
 
 How to link depends on if you are linking to an external URL or to another page in the documentation.

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -177,6 +177,56 @@ Output is the main content of the directive.
 To override the prompt (``user@host:~$`` by default), specify the ``:user:`` and/or ``:host:`` options.
 To make the terminal scroll horizontally instead of wrapping long lines, add ``:scroll:``.
 
+Command input and output
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you are not trying to visually simulate a terminal, separate the input and output code blocks.
+Do not prefix commands with ``$`` as this is not user-friendly. Users should be able to copy and paste the command without requiring edits.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type
+     - Restructured text
+     - Rendering
+   * - Input
+     - .. code::
+
+          .. code:: bash
+
+            docker volume inspect my-vol
+
+     - .. code:: bash
+
+          docker volume inspect my-vol
+
+   * - Output
+     - .. code::
+
+          .. code:: json
+
+            [
+              {
+                "Driver": "local",
+                "Labels": {},
+                "Mountpoint": "/var/lib/docker/volumes/my-vol/_data",
+                "Name": "my-vol",
+                "Scope": "local"
+              }
+            ]
+
+     - .. code:: json
+
+          [
+            {
+              "Driver": "local",
+              "Labels": {},
+              "Mountpoint": "/var/lib/docker/volumes/my-vol/_data",
+              "Name": "my-vol",
+              "Scope": "local"
+            }
+          ]
+
 Links
 -----
 


### PR DESCRIPTION
The Canonical documentation doesn’t have a standard way to define a command and its output within a code block. I noticed it while working on the Juju and Ubuntu server documentation. On Github, an issue and a comment have also been raised in the [Juju](https://github.com/juju/juju/issues/18883) and [Ubuntu server](https://github.com/canonical/ubuntu-server-documentation/pull/206/files/4b3dd4d79ad9eda3c99c8aef12b6fcc4b25e0caa..868f52800cfde952682c11472c6d9e85115a1a1f#r2017748137) repository.

When a code block has an input and output, a few contents represent an input with a shell symbol, “$”, and nothing to represent an output. Other parts of the content don’t. My suggestion is to define the input in one code block and the output in another code block. This is because sometimes, the output may be in JSON format.

-----

- [x] Have you updated the documentation for this change?

