### PR TITLE
Fix: update related links header to use Sphinx original URL

### DIFF
--- a/docs/reference/style-guide-myst.md
+++ b/docs/reference/style-guide-myst.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://github.com/canonical/canonical-sphinx-extensions, https://tinyurl.com/rstprimer, [Canonical&#32;Documentation&#32;Style&#32;Guide](https://docs.ubuntu.com/styleguide/en)
+relatedlinks: https://github.com/canonical/canonical-sphinx-extensions, [reStructuredText&#32;Primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html), [Canonical&#32;Documentation&#32;Style&#32;Guide](https://docs.ubuntu.com/styleguide/en)
 myst:
   substitutions:
     advanced_reuse_key: "This is a substitution that includes a code block:

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -1,4 +1,4 @@
-:relatedlinks: https://github.com/canonical/lxd-sphinx-extensions, https://tinyurl.com/rstprimer, [Canonical&#32;Documentation&#32;Style&#32;Guide](https://docs.ubuntu.com/styleguide/en)
+:relatedlinks: https://github.com/canonical/lxd-sphinx-extensions, [reStructuredText&#32;Primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html), [Canonical&#32;Documentation&#32;Style&#32;Guide](https://docs.ubuntu.com/styleguide/en)
 
 .. _style-guide:
 


### PR DESCRIPTION
This PR stores the short URL in the `related link` field, using the original link to avoid third-party stability and maintenance issues.

## Problem

A third-party link in the `related link` header (a short URL pointing to the Sphinx documentation) causes the doc build to fail because its SSL certificate verification failed ([action run failure](https://github.com/canonical/sphinx-docs-starter-pack/actions/runs/14698551899/job/41243915097) and [RTD build failure](https://app.readthedocs.com/projects/canonical-starter-pack/builds/3002075/))

Error message during HTML build:
```
WARNING: reference/style-guide: HTTPSConnectionPool(host='tinyurl.com', port=443): Max retries exceeded with url: /rstprimer (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)')))
WARNING: reference/style-guide-myst: HTTPSConnectionPool(host='tinyurl.com', port=443): Max retries exceeded with url: /rstprimer (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)')))
```

## Related info
- This link was introduced in https://github.com/canonical/sphinx-docs-starter-pack/pull/46 to bypass woke check on `master` keyword
- There is an open Sphinx issue requesting option to ignore this behaviour: https://github.com/sphinx-doc/sphinx/issues/12985