### PR TITLE
Switch the recommendation to Sphinx design tabs

### DIFF
--- a/docs/reference/doc-cheat-sheet-myst.md
+++ b/docs/reference/doc-cheat-sheet-myst.md
@@ -193,13 +193,13 @@ Keys can be defined at the top of a file, or in a `myst_substitutions` option in
 
 ## Tabs
 
-````{tabs}
-```{group-tab} Tab 1
+````{tab-set}
+```{tab-item} Tab 1
 
 Content Tab 1
 ```
 
-```{group-tab} Tab 2
+```{tab-item} Tab 2
 Content Tab 2
 ```
 ````

--- a/docs/reference/doc-cheat-sheet.rst
+++ b/docs/reference/doc-cheat-sheet.rst
@@ -211,13 +211,13 @@ Reuse
 Tabs
 ----
 
-.. tabs::
+.. tab-set::
 
-   .. group-tab:: Tab 1
+   .. tab-item:: Tab 1
 
       Content Tab 1
 
-   .. group-tab:: Tab 2
+   .. tab-item:: Tab 2
 
       Content Tab 2
 

--- a/docs/reference/style-guide-myst.md
+++ b/docs/reference/style-guide-myst.md
@@ -699,46 +699,7 @@ Adhere to the following convention:
 
 ## Tabs
 
-The recommended way of creating tabs is to use the [Sphinx tabs](https://sphinx-tabs.readthedocs.io/en/latest/) extension, which remembers the selected tab (also when navigating to other pages).
-
-``````{list-table}
-   :header-rows: 1
-
-* - Input
-  - Output
-* - `````
-
-    ````{tabs}
-
-    ```{group-tab} Tab 1
-
-    Content Tab 1
-    ```
-
-    ```{group-tab} Tab 2
-
-    Content Tab 2
-    ```
-
-    ````
-
-    `````
-
-  - ````{tabs}
-
-    ```{group-tab} Tab 1
-
-    Content Tab 1
-    ```
-
-    ```{group-tab} Tab 2
-
-    Content Tab 2
-    ```
-    ````
-``````
-
-Alternatively, if you use tabs only occasionally and don't want to include an additional extension for them, you can use the basic tabs that the [Sphinx design](https://sphinx-design.readthedocs.io/en/latest/) extension provides.
+The recommended way of creating tabs is to use the tabs that the [Sphinx design](https://sphinx-design.readthedocs.io/en/latest/) extension provides.
 
 ``````{list-table}
    :header-rows: 1
@@ -775,6 +736,45 @@ Alternatively, if you use tabs only occasionally and don't want to include an ad
 
     ```{tab-item} Tab 2
     :sync: key2
+
+    Content Tab 2
+    ```
+    ````
+``````
+
+Alternatively, you can use the [Sphinx tabs](https://sphinx-tabs.readthedocs.io/en/latest/) extension, which is also enabled by default. This was previously recommended due to limitations in Sphinx Design that are now fixed.
+
+``````{list-table}
+   :header-rows: 1
+
+* - Input
+  - Output
+* - `````
+
+    ````{tabs}
+
+    ```{group-tab} Tab 1
+
+    Content Tab 1
+    ```
+
+    ```{group-tab} Tab 2
+
+    Content Tab 2
+    ```
+
+    ````
+
+    `````
+
+  - ````{tabs}
+
+    ```{group-tab} Tab 1
+
+    Content Tab 1
+    ```
+
+    ```{group-tab} Tab 2
 
     Content Tab 2
     ```

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -456,9 +456,9 @@ Lists
 
 You can also nest lists:
 
-.. tabs::
+.. tab-set::
 
-   .. group-tab:: Input
+   .. tab-item:: Input
 
       .. code::
 
@@ -477,7 +477,7 @@ You can also nest lists:
 
                - Item
             #. Sub-step 2
-   .. group-tab:: Output
+   .. tab-item:: Output
 
 
 
@@ -753,38 +753,7 @@ Adhere to the following conventions:
 Tabs
 ----
 
-The recommended way of creating tabs is to use the `Sphinx tabs`_ extension, which remembers the selected tab (also when navigating to other pages).
-
-.. list-table::
-   :header-rows: 1
-
-   * - Input
-     - Output
-   * - .. code::
-
-          .. tabs::
-
-             .. group-tab:: Tab 1
-
-                Content Tab 1
-
-             .. group-tab:: Tab 2
-
-                Content Tab 2
-     - .. tabs::
-
-          .. group-tab:: Tab 1
-
-             Content Tab 1
-
-          .. group-tab:: Tab 2
-
-             Content Tab 2
-
-Alternatively, if you use tabs only occasionally and don't want to include an additional extension for them, you can use the basic tabs that the `Sphinx design`_ extension provides.
-
-.. note::
-   The Sphinx design tabs sync within a page, but if you navigate to another page, the selection is lost.
+The recommended way of creating tabs is to use the tabs that the `Sphinx design`_ extension provides.
 
 .. list-table::
    :header-rows: 1
@@ -815,6 +784,34 @@ Alternatively, if you use tabs only occasionally and don't want to include an ad
             :sync: key2
 
             Content Tab 2
+
+Alternatively, you can use the `Sphinx tabs`_ extension, which is also enabled by default. This was previously recommended due to limitations in Sphinx Design that are now fixed.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - .. code::
+
+          .. tabs::
+
+             .. group-tab:: Tab 1
+
+                Content Tab 1
+
+             .. group-tab:: Tab 2
+
+                Content Tab 2
+     - .. tabs::
+
+          .. group-tab:: Tab 1
+
+             Content Tab 1
+
+          .. group-tab:: Tab 2
+
+             Content Tab 2
 
 Glossary
 --------


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----

Previously, the style guide recommended using the [Sphinx tabs](https://sphinx-tabs.readthedocs.io/en/latest/) extension for creating tabs. The reason was that the tabs available from the [Sphinx design](https://sphinx-design.readthedocs.io/en/latest/) extension didn't synchronize across pages.

However, @edibotopic and I tested the tabs last week, and both extensions can now synchronize properly, removing the need for Sphinx tabs.

In addition, Sphinx tabs have their own issues:

- When you switch tabs, the tabs visually jump about a pixel to the left or right. Tested in Firefox and Chromium.
- They don't work in the PDF output. See #302.
- They require an additional extension.

Since Sphinx tabs don't seem to provide any benefits nowadays and only cause issues, I propose that we switch the default recommendation to Sphinx design tabs instead.

For reference, the Sphinx tabs recommendation was made by Ruth Fuchss in March 2023 (commit https://github.com/canonical/sphinx-docs-guide/commit/83540b7942755a7804b3944c4332e9bc969f3980) and further developed in January 2024 (commit https://github.com/canonical/sphinx-docs-guide/commit/9138129499e68ed0d906a9fe9d57e4b4b5939445).