### PR TITLE
Optimize the Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Simplifies vale binary download & install.
 * Leaves vale install output in STDOUT to reveal potential problems.
 * Improves update logic.
+* Update Makefile logic
 
 ## 1.0.1
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,10 +42,10 @@ help:
 	@echo "-------------------------------------------------------------"
 	@echo
 
-.PHONY: full-help spellcheck-install pa11y-install install run html \
-        epub serve clean clean-doc spelling spellcheck linkcheck woke \
-        allmetrics pa11y pdf-prep-force pdf-prep pdf vale-install vale \
-		update
+.PHONY: help full‑help html epub pdf linkcheck spelling spellcheck woke \
+        vale pa11y run serve install spellcheck‑install pa11y‑install   \
+        vale‑install pdf‑prep pdf‑prep‑force clean clean‑doc allmetrics \
+        update
 
 full-help: $(VENVDIR)
 	@. $(VENV); $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -193,4 +193,5 @@ update: install
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %:
+	$(MAKE) —no-print-directory install
 	. $(VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
Per @desrod's suggestion:

Small changes to group .PHONY targets logically together and introduce proper, recursive ${MAKE} instead of statically calling 'make' each time through. More to time!

- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----
