### PR TITLE
chore: switch to american english

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # sphinx-docs-starter-pack changelog
 
+## 1.1.1
+
+* Switched to American English
+
+### Changed
+
+* `docs/.sphinx/spellingcheck.yaml` [#394](https://github.com/canonical/sphinx-docs-starter-pack/pull/394)
+
 ## 1.1.0
 
 * Adds sitemap support.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Documentation starter pack includes:
 * A bundled [Sphinx] theme, configuration, and extensions
 * Support for both reStructuredText (reST) and MyST Markdown
 * Build checks for links, spelling, and inclusive language
-* Customisation support layered over a core configuration
+* Customization support layered over a core configuration
 
 See the full documentation: https://canonical-starter-pack.readthedocs-hosted.com/
 

--- a/docs/.sphinx/metrics/build_metrics.sh
+++ b/docs/.sphinx/metrics/build_metrics.sh
@@ -9,7 +9,7 @@ links=$(find . -type d -path './.sphinx' -prune -o -name '*.html' -exec cat {} +
 # count number of images
 images=$(find . -type d -path './.sphinx' -prune -o -name '*.html' -exec cat {} + | grep -o "<img " | wc -l)
 
-# summarise latest metrics
-echo "Summarising metrics for build files (.html)..."
+# summarize latest metrics
+echo "Summarizing metrics for build files (.html)..."
 echo -e "\tlinks: $links"
 echo -e "\timages: $images"

--- a/docs/.sphinx/metrics/source_metrics.sh
+++ b/docs/.sphinx/metrics/source_metrics.sh
@@ -55,8 +55,8 @@ else
         readable=false
     fi
 
-    # summarise latest metrics
-    echo "Summarising metrics for source files (.md, .rst)..."
+    # summarize latest metrics
+    echo "Summarizing metrics for source files (.md, .rst)..."
     echo -e "\ttotal files: $files"
     echo -e "\ttotal words (raw): $words"
     echo -e "\ttotal words (prose): $readabilityWords"

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -2,7 +2,7 @@ matrix:
   - name: rST files
     aspell:
       lang: en
-      d: en_GB
+      d: en_US
     dictionary:
       wordlists:
         - .sphinx/.wordlist.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # Minimal makefile for Sphinx documentation
 #
-# Add your customisation to `Makefile` instead.
+# Add your customization to `Makefile` instead.
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,14 +83,14 @@ ogp_site_name = project
 
 # Preview image URL
 #
-# TODO: To customise the preview image, update as needed.
+# TODO: To customize the preview image, update as needed.
 
 ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg"
 
 
 # Product favicon; shown in bookmarks, browser tabs, etc.
 
-# TODO: To customise the favicon, uncomment and update as needed.
+# TODO: To customize the favicon, uncomment and update as needed.
 
 # html_favicon = '.sphinx/_static/favicon.png'
 
@@ -136,13 +136,13 @@ html_context = {
     "github_url": "https://github.com/canonical/sphinx-docs-starter-pack",
     # Docs branch in the repo; used in links for viewing the source files
     #
-    # TODO: To customise the branch, uncomment and update as needed.
+    # TODO: To customize the branch, uncomment and update as needed.
     'repo_default_branch': 'main',
     # Docs location in the repo; used in links for viewing the source files
     #
 
 
-    # TODO: To customise the directory, uncomment and update as needed.
+    # TODO: To customize the directory, uncomment and update as needed.
     "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
@@ -150,7 +150,7 @@ html_context = {
     # TODO: To enable listing contributors on individual pages, set to True
     "display_contributors": False,
 
-    # Required for feedback button    
+    # Required for feedback button
     'github_issues': 'enabled',
 }
 

--- a/docs/how-to/build.rst
+++ b/docs/how-to/build.rst
@@ -68,7 +68,7 @@ When you change a documentation file and save it, the documentation will be auto
    However, it is quite error-prone because it displays warnings or errors only when they occur.
    If you save other files later, you might miss these messages.
 
-   Therefore, you should always :ref:`build-clean` before finalising your changes.
+   Therefore, you should always :ref:`build-clean` before finalizing your changes.
 
 Build a PDF
 -----------
@@ -101,10 +101,10 @@ On Linux, required packages can be installed with:
 .. code-block:: none
 
     make pdf-prep-force
-    
+
 .. note::
 
-    When generating a PDF, the index page is considered a 'foreword' and will not be labelled with a chapter.
+    When generating a PDF, the index page is considered a 'foreword' and will not be labeled with a chapter.
 
 .. important::
 

--- a/docs/how-to/contributing-myst.md
+++ b/docs/how-to/contributing-myst.md
@@ -19,13 +19,13 @@ The guidelines below will help keep your contributions effective and meaningful.
 
 When contributing, you must abide by the [Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct).
 
-## Licence and copyright
+## License and copyright
 
 <!-- TODO: Update with your license details or drop if excessive -->
 
-By default, all contributions to ACME are made under the AGPLv3 licence. See the [licence](https://github.com/canonical/ACME/blob/main/COPYING) in the ACME GitHub repository for details.
+By default, all contributions to ACME are made under the AGPLv3 license. See the [license](https://github.com/canonical/ACME/blob/main/COPYING) in the ACME GitHub repository for details.
 
-All contributors must sign the [Canonical contributor licence agreement](https://ubuntu.com/legal/contributors), which grants Canonical permission to use the contributions. The author of a change remains the copyright owner of their code (no copyright assignment occurs).
+All contributors must sign the [Canonical contributor license agreement](https://ubuntu.com/legal/contributors), which grants Canonical permission to use the contributions. The author of a change remains the copyright owner of their code (no copyright assignment occurs).
 
 ## Releases and versions
 
@@ -71,7 +71,7 @@ Your changes will be reviewed in due time; if approved, they will eventually be 
 
 To be properly considered, reviewed, and merged, your pull request must provide the following details:
 
-- **Title**: Summarise the change in a short, descriptive title.
+- **Title**: Summarize the change in a short, descriptive title.
 - **Description**: Explain the problem that your pull request solves. Mention any new features, bug fixes, or refactoring.
 - **Relevant issues**: Reference any [related issues, pull requests, and repositories](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls).
 - **Testing**: Explain whether new or updated tests are included.
@@ -174,12 +174,12 @@ TODO: lint command 2
 ### Structure
 
 - **Check linked code elements**: Ensure coupled code elements, files, and directories are adjacent. For instance, store test data close to the corresponding test code.
-- **Group variable declaration and initialisation**: Declare and initialise variables together to improve code organisation and readability.
+- **Group variable declaration and initialization**: Declare and initialize variables together to improve code organization and readability.
 - **Split large expressions**: Break down large expressions into smaller self-explanatory parts. Use multiple variables where appropriate to make the code more understandable and choose names that reflect their purpose.
 - **Use blank lines for logical separation**: Insert a blank line between two logically separate sections of code to improve its structure and readability.
 - **Avoid nested conditions**: Avoid nesting conditions to improve readability and maintainability.
 - **Remove dead code and redundant comments**: Drop unused or obsolete code and comments to promote a cleaner code base and reduce confusion.
-- **Normalise symmetries**: Treat identical operations consistently, using a uniform approach to improve consistency and readability.
+- **Normalize symmetries**: Treat identical operations consistently, using a uniform approach to improve consistency and readability.
 
 ### Best practices
 

--- a/docs/how-to/contributing.rst
+++ b/docs/how-to/contributing.rst
@@ -33,16 +33,16 @@ When contributing, you must abide by the
 `Ubuntu Code of Conduct <https://ubuntu.com/community/ethos/code-of-conduct>`_.
 
 
-Licence and copyright
+License and copyright
 ---------------------
 
 .. TODO: Update with your license details or drop if excessive
 
-By default, all contributions to ACME are made under the AGPLv3 licence.
-See the `licence <https://github.com/canonical/ACME/blob/main/COPYING>`_
+By default, all contributions to ACME are made under the AGPLv3 license.
+See the `license <https://github.com/canonical/ACME/blob/main/COPYING>`_
 in the ACME GitHub repository for details.
 
-All contributors must sign the `Canonical contributor licence agreement
+All contributors must sign the `Canonical contributor license agreement
 <https://ubuntu.com/legal/contributors>`_,
 which grants Canonical permission to use the contributions.
 The author of a change remains the copyright owner of their code
@@ -115,7 +115,7 @@ Describing pull requests
 To be properly considered, reviewed and merged,
 your pull request must provide the following details:
 
-- **Title**: Summarise the change in a short, descriptive title.
+- **Title**: Summarize the change in a short, descriptive title.
 
 - **Description**: Explain the problem that your pull request solves.
   Mention any new features, bug fixes or refactoring.
@@ -146,10 +146,10 @@ to ensure consistency across the project:
 .. code-block:: none
 
    Ensure correct permissions and ownership for the content mounts
-    
+
     * Work around an ACME issue regarding empty dirs:
       https://github.com/canonical/ACME/issues/12345
-    
+
     * Ensure the source directory is owned by the user running a container.
 
    Links:
@@ -242,9 +242,9 @@ Structure
   Check that coupled code elements, files and directories are adjacent.
   For instance, store test data close to the corresponding test code.
 
-- **Group variable declaration and initialisation**:
-  Declare and initialise variables together
-  to improve code organisation and readability.
+- **Group variable declaration and initialization**:
+  Declare and initialize variables together
+  to improve code organization and readability.
 
 - **Split large expressions**:
   Break down large expressions
@@ -264,7 +264,7 @@ Structure
   Drop unused or obsolete code and comments.
   This promotes a cleaner code base and reduces confusion.
 
-- **Normalise symmetries**:
+- **Normalize symmetries**:
   Treat identical operations consistently, using a uniform approach.
   This also improves consistency and readability.
 

--- a/docs/how-to/customize-pdf.rst
+++ b/docs/how-to/customize-pdf.rst
@@ -1,6 +1,6 @@
-.. _pdf-customise:
+.. _pdf-customize:
 
-Customise PDF output
+Customize PDF output
 ====================
 
 Overview
@@ -8,12 +8,12 @@ Overview
 
 The starter pack supports PDF output via LaTeX using the ``make pdf`` command. This build process relies on system packages, Sphinx configurations, and a LaTeX template from the ``canonical-sphinx`` extension.
 
-Customising PDF output involves two levels of configuration:
+Customizing PDF output involves two levels of configuration:
 
 * **Sphinx configuration**: built-in options for configuring LaTeX build process in :file:`conf.py`, for example: the engine used to generate the PDF, output file name, and input file paths.
 * **LaTeX configuration**: the LaTeX packages, styling, and configuration for the PDF output, set through the `latex_elements <https://www.sphinx-doc.org/en/master/latex.html#the-latex-elements-configuration-setting>`_ dictionary in the project :file:`conf.py`. In the starter-pack, a default set of LaTeX elements is provided by the ``canonical-sphinx`` extension. Changing the LaTeX configuration requires overriding the default values loaded from the extension.
 
-This guide covers common practices and tips for customising PDF output from your documentation project using the starter pack and the ``canonical-sphinx`` extension.
+This guide covers common practices and tips for customizing PDF output from your documentation project using the starter pack and the ``canonical-sphinx`` extension.
 
 For basic instructions about building the PDF, see :doc:`build`.
 
@@ -52,7 +52,7 @@ For more details, see `latex_documents`_ in the Sphinx documentation.
 Change PDF document filename
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the PDF output filename is derived from the ``project`` name in the :file:`conf.py` file: lowercase characters with blank spaces removed. 
+By default, the PDF output filename is derived from the ``project`` name in the :file:`conf.py` file: lowercase characters with blank spaces removed.
 
 To override the filename, update the second element (``targetname``) of the ``latex_documents`` tuple in :file:`conf.py`. The following example shows how to replace blank spaces in the project name with underscores:
 
@@ -72,7 +72,7 @@ To override the filename, update the second element (``targetname``) of the ``la
 Change PDF document title
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the PDF title on the cover page comes from the title of the main index document. To override it, update the third element (title) of the ``latex_documents`` tuple in :file:`conf.py`. Use an empty string (``''``) to keep the default behaviour.
+By default, the PDF title on the cover page comes from the title of the main index document. To override it, update the third element (title) of the ``latex_documents`` tuple in :file:`conf.py`. Use an empty string (``''``) to keep the default behavior.
 
 Use a different index document for PDF builds
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -124,8 +124,8 @@ Any additions or changes to the default settings of LaTeX elements in the PDF do
 .. code-block:: python
 
    # Replace with the path to your local override file
-   latex_elements_file = ".sphinx/latex_elements_custom.txt"  
-   
+   latex_elements_file = ".sphinx/latex_elements_custom.txt"
+
    with open(latex_elements_file, "rt") as file:
       latex_config = file.read()
       if latex_elements == {}:
@@ -154,14 +154,14 @@ You can use two methods to add additional LaTeX packages to the preamble:
 
 * Modify the values of the ``preamble`` key in your local template file. This is more flexible for adding LaTeX configurations and commands to the preamble.
 
-.. note:: 
+.. note::
    The format of the element values is a multi-line string, so use a raw string with the ``r`` prefix.
 
 
 Remove the table of contents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For a short, compact document where navigation is not needed, you may want to remove the table of contents from the PDF output. 
+For a short, compact document where navigation is not needed, you may want to remove the table of contents from the PDF output.
 
 To do this, provide a local copy of the default template file, and add a new key ``tableofcontents`` with an empty string as the value:
 
@@ -173,7 +173,7 @@ To do this, provide a local copy of the default template file, and add a new key
       'tableofcontents': '',
       ...
    }
-   
+
 
 Include images or other assets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -190,7 +190,7 @@ Provide a ``latex_additional_files`` variable in :file:`conf.py` as a list of fi
       'path/to/other-asset.pdf',
    ]
 
-.. note:: 
+.. note::
    For better quality in the PDF output, it is recommended to use vector images (like SVG or PDF) rather than raster images (like PNG or JPEG). Raster images may lose quality when scaled up in the PDF.
 
    Do not use ``.tex`` as suffix, otherwise the file is processed as source files for the PDF build process. Instead, use ``.tex.txt`` or ``.sty``  to avoid conflicts with the LaTeX build process.
@@ -211,7 +211,7 @@ The PDF output uses portrait orientation by default. To use landscape orientatio
          ...
       }
 
-   .. note:: 
+   .. note::
       The format of the element values is a multi-line string, so use a raw string with the ``r`` prefix.
 
 2. Use the landscape environment in your documentation source file, and only in the PDF output.
@@ -262,4 +262,4 @@ To temporarily save the log files for debugging:
 Related
 -------
 - :doc:`build`
-- :doc:`customise`
+- :doc:`customize`

--- a/docs/how-to/customize.rst
+++ b/docs/how-to/customize.rst
@@ -1,6 +1,6 @@
-.. _customise:
+.. _customize:
 
-Customise the setup
+Customize the setup
 ===================
 
 .. important::
@@ -19,7 +19,7 @@ However, you must set some critical parameters that are unique for your project,
 
 In addition, you can find some optional parameters or add your own configuration parameters to the file.
 
-Required customisation
+Required customization
 ----------------------
 
 You must check and update some of the parameters specific to your project.
@@ -49,12 +49,12 @@ Adjust the header
 The header is the top section of a page template.
 By default, the starter pack template header contains your product's tag image and name (taken from the ``project`` setting in the :file:`docs/conf.py` file), a link to your product's page (if available), and a drop-down menu for "More resources".
 
-The default configuration is sufficient for many cases but can be further customised.
+The default configuration is sufficient for many cases but can be further customized.
 
 You can change any of those links or add further links to the "More resources" drop-down by editing the :file:`.sphinx/_templates/header.html` file.
 For example, you might want to add links to announcements, tutorials, getting started guides, or videos that are not part of the documentation.
 
-Optional customisation
+Optional customization
 ----------------------
 
 The starter pack contains several features that you can configure, or turn off if they aren't suitable for your documentation.
@@ -92,7 +92,7 @@ Configure included extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The starter pack includes a set of extensions that are useful for all documentation sets.
-They are pre-configured as needed, but you can customise their configuration in the  :file:`docs/conf.py` file.
+They are pre-configured as needed, but you can customize their configuration in the  :file:`docs/conf.py` file.
 
 The following extensions are included by default:
 

--- a/docs/how-to/edit.rst
+++ b/docs/how-to/edit.rst
@@ -3,13 +3,13 @@
 Edit content
 ============
 
-The landing page is stored in the :file:`docs/index.rst` file 
+The landing page is stored in the :file:`docs/index.rst` file
 while the rest of the pages are stored in the :file:`docs/content/` folder by default.
 
 The Navigation Menu structure is set by ``.. toctree::`` directives. These directives define the hierarchy of included content throughout the documentation.
 The :file:`index.rst` page's ``toctree`` block contains the top level Navigation Menu.
 
-To add a new page to the documentation:    
+To add a new page to the documentation:
 
 1. Create a new file in the `docs/content` folder. For example, to create the **Reference** page, create a document called :file:`reference.rst`, insert the following |RST|-formatted heading ``Reference`` at the beginning, and then save the file:
 
@@ -23,7 +23,7 @@ To add a new page to the documentation:
 
    .. code-block:: markdown
       :caption: Markdown title example
-         
+
          # Reference
 
 2. Add the new page to the Navigation Menu: open the :file:`index.rst` file or another file where you want to nest the new page; at the bottom of the file, locate the ``toctree`` directive and add a properly indented line containing the path (without a file extension) to the new file created in the first step. For example, ``content/reference``.
@@ -31,13 +31,13 @@ To add a new page to the documentation:
    The ``toctree`` block will now look like this:
 
    .. code-block:: rest
-         
+
          .. toctree::
             :hidden:
             :maxdepth: 2
-         
+
             Set up the documentation <set-up>
-            customise
+            customize
             rtd
             update
             automatic_checks

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -8,9 +8,9 @@ maintaining, and contributing to the starter pack.
    :maxdepth: 1
 
    rtd
-   customise
+   customize
    set-up-sitemaps
-   customise-pdf
+   customize-pdf
    migrate-from-pre-extension
    update
    contributing

--- a/docs/how-to/migrate-from-pre-extension.rst
+++ b/docs/how-to/migrate-from-pre-extension.rst
@@ -1,4 +1,4 @@
-Migrate from the pre-extension starter pack 
+Migrate from the pre-extension starter pack
 ===========================================
 
 This guide outlines the steps required to migrate a documentation project from the legacy Sphinx Documentation Starter Pack (*pre-extension* version) to the latest version that adopts the ``canonical-sphinx`` Sphinx extension.
@@ -9,7 +9,7 @@ The extension-based documentation starter pack provides a set of features and co
 Update to the last pre-extension version
 ----------------------------------------
 
-To ensure a smooth migration, update your documentation project to use the last pre-extension version of the Sphinx Documentation Starter Pack. This update ensures that your project is using the latest features and configurations available, minimising the changes required during the migration.
+To ensure a smooth migration, update your documentation project to use the last pre-extension version of the Sphinx Documentation Starter Pack. This update ensures that your project is using the latest features and configurations available, minimizing the changes required during the migration.
 
 You can find the release tag and branch for this version in the following links:
 
@@ -26,13 +26,13 @@ Set up a new project
 
       If you proceed in the same directory, the following steps will overwrite some of the configuration files in the original project.
 
-2. Follow the steps in the :ref:`initial-setup` guide to initialise an empty project with the extension-based starter pack, at the original file path.
+2. Follow the steps in the :ref:`initial-setup` guide to initialize an empty project with the extension-based starter pack, at the original file path.
 
 3. Ensure the following files are at the root of your repository:
 
    - ``.github/workflows/*``
 
-4. Ensure the following files are moved to their original paths in the project. These files are defaulted to the repository root, but may have be changed upon project needs: 
+4. Ensure the following files are moved to their original paths in the project. These files are defaulted to the repository root, but may have be changed upon project needs:
 
    - ``.gitignore``
    - ``.readthedocs.yml``
@@ -54,14 +54,14 @@ For a complete list of the structural changes, refer to the `directory-structure
 Sphinx configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
-A significant change in the new starter pack is the organisation of the configuration files, summarised in the following table:
+A significant change in the new starter pack is the organization of the configuration files, summarized in the following table:
 
 .. list-table::
    :widths: 20 40 40
    :header-rows: 1
 
    * - Configuration file
-     - Pre-extension 
+     - Pre-extension
      - Extension-based
    * - ``conf.py``
      - Common configurations shared by all starter pack projects
@@ -72,7 +72,7 @@ A significant change in the new starter pack is the organisation of the configur
 
 In the new starter pack, many common configurations are provided by the extension and are loaded automatically when building the documentation. ``docs/conf.py`` is the only configuration file, and it contains all project-specific configuration. Sensible defaults are set for general configuration by inclusion of the `canonical-sphinx` extension.
 
-Ensure that all the previous changes in the original ``custom_conf.py`` file are copied to the new ``conf.py`` file.  
+Ensure that all the previous changes in the original ``custom_conf.py`` file are copied to the new ``conf.py`` file.
 
 Dependencies
 ~~~~~~~~~~~~
@@ -86,8 +86,8 @@ Documentation source files
 
 2. Copy all documentation source files from your original project to the new project, keeping their original structure. These file may include but are not limited to:
 
-   - ``.md`` 
-   - ``.rst`` 
+   - ``.md``
+   - ``.rst``
    - ``.txt``
    - ``.json``
    - images
@@ -95,27 +95,27 @@ Documentation source files
 
 3. Validate the migration by running ``make run``.
 
-Apply customisation
+Apply customization
 -------------------
 
 If your projects have custom configurations or styles, ensure that you identify and apply these changes to the new documentation project.
 
-For general information on customising the extension configuration, see :doc:`customise`.
+For general information on customizing the extension configuration, see :doc:`customize`.
 
 Static resources
 ~~~~~~~~~~~~~~~~
 
 The extension provides a set of static resources, such as images, fonts, CSS files, and HTML templates, that are used to style the documentation for Canonical-branded design. These resources are bundled with the extension and are no longer provided as source files in the new starter pack.
 
-If you have customised any of these resources in the original project, you need to manually migrate these changes to the new project. 
+If you have customized any of these resources in the original project, you need to manually migrate these changes to the new project.
 
-For example, if you added customised styling in the original ``.sphinx/_static/custom.css`` file, follow the steps:
+For example, if you added customized styling in the original ``.sphinx/_static/custom.css`` file, follow the steps:
 
-1. Compare the changes between your customised file and the `default CSS file provided by the extension <https://github.com/canonical/canonical-sphinx/blob/main/canonical_sphinx/theme/static/custom.css>`_. This comparison helps you identify the changes that need to be migrated to the new project.
+1. Compare the changes between your customized file and the `default CSS file provided by the extension <https://github.com/canonical/canonical-sphinx/blob/main/canonical_sphinx/theme/static/custom.css>`_. This comparison helps you identify the changes that need to be migrated to the new project.
 2. Create a new CSS file under ``docs/.sphinx/_static``. You can choose any other file location in the project directory, but it's recommended to keep the file structure similar to the original project.
 3. Copy the additions and changes to the new empty file.
 4. In the ``conf.py``, add the new files into the pre-defined ``html_css_files`` list variable to overwrite the default settings.
-5. Build the documentation to verify that the customised styling is applied correctly.
+5. Build the documentation to verify that the customized styling is applied correctly.
 
 
 .. _directory-structure-change:
@@ -175,8 +175,8 @@ Assuming that all previous documentation files were in the ``docs/`` sub-directo
     │   └── spellingcheck.yaml
     ├── metrics                     # moved to `docs/.sphinx/metrics/`
     │   └── scripts                 # removed, files moved to parent directory
-    │       ├── build_metrics.sh   
-    │       └── source_metrics.sh   
+    │       ├── build_metrics.sh
+    │       └── source_metrics.sh
     ├── reuse                       # moved to `docs/reuse`
     │   └── links.txt
     ├── .custom_wordlist.txt        # moved to `docs/.custom_wordlist.txt`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ In this documentation
       :link: /how-to/index
       :link-type: doc
 
-      **Step-by-step guides** - learn key operations and customisation.
+      **Step-by-step guides** - learn key operations and customization.
 
 .. grid:: 1 1 2 2
 

--- a/docs/reference/automatic_checks_inclusivelanguage.rst
+++ b/docs/reference/automatic_checks_inclusivelanguage.rst
@@ -38,7 +38,7 @@ For instance::
 
    Vale will lint the displayed text of a link, not the URL of a link. If you
    wish to use a link that contains non-inclusive language, use appropriate link
-   text with the syntax appropriate for your source file. 
+   text with the syntax appropriate for your source file.
 
 Exempt a word globally
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -48,7 +48,7 @@ To exempt a word, add it to this file globally.
 
 .. note::
 
-   Entries in ``.custom-wordlist`` are case-sensitive only when a capitalised word is used. For instance:
+   Entries in ``.custom-wordlist`` are case-sensitive only when a capitalized word is used. For instance:
 
    - Adding ``kustom`` will cause all instances of ``Kustom`` and ``kustom`` to be ignored.
    - Adding ``Kustom`` will cause only instances of ``Kustom`` to be ignored.

--- a/docs/reference/doc-cheat-sheet-myst.md
+++ b/docs/reference/doc-cheat-sheet-myst.md
@@ -107,7 +107,7 @@ Term 2
 | Cell 1<br>Second paragraph         | Cell 2   |
 | Cell 3                             | Cell 4   |
 
-Centred:
+Centered:
 
 | Header 1                           | Header 2 |
 |:----------------------------------:|:--------:|
@@ -129,7 +129,7 @@ Centred:
   - Cell 4
 ```
 
-Centred:
+Centered:
 
 ```{list-table}
    :header-rows: 1

--- a/docs/reference/style-guide-myst.md
+++ b/docs/reference/style-guide-myst.md
@@ -46,7 +46,7 @@ Adhere to the following conventions:
 
 - Do not use consecutive headings without intervening text.
 - Do not skip levels (for example, do not follow an H2 heading with an H4 heading).
-- Use sentence style for headings (capitalise only the first word).
+- Use sentence style for headings (capitalize only the first word).
 
 ## Inline formatting
 

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -56,7 +56,7 @@ Adhere to the following conventions:
 - Do not use consecutive headings without intervening text.
 - Be consistent with the characters you use for each level.
   Use the ones specified above.
-- Use sentence style for headings (capitalise only the first word).
+- Use sentence style for headings (capitalize only the first word).
 
 Inline formatting
 -----------------

--- a/docs/tutorial/set-up.rst
+++ b/docs/tutorial/set-up.rst
@@ -42,7 +42,7 @@ The landing page is :file:`docs/index.rst`. Other pages are under :file:`docs/co
 Configure settings
 ==================
 
-Work through the settings in :file:`docs/conf.py`. Most parameters can be left with the default values as they can be changed later. :ref:`customise` contains further guidance.
+Work through the settings in :file:`docs/conf.py`. Most parameters can be left with the default values as they can be changed later. :ref:`customize` contains further guidance.
 
 
 Pre-commit hooks (optional)


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----

There was a [content guide](https://discourse.canonical.com/t/style-guide-switch-to-us-english/4797) released a few months back that advised us to switch to American English for web content. If it's also true for documentation, it makes sense to update the starter pack as well to match.. If it isn't, feel free to close this 😅.
