### PR TITLE
Clarify instructions for sitemaps

### DIFF
--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -35,6 +35,9 @@ configuration file. For example, in :file:`docs/conf.py`:
 
     html_baseurl = 'https://canonical-starter-pack.readthedocs-hosted.com/'
 
+Make sure to include the trailing slash (`/`) to avoid errors in the concatenated
+URLs in the sitemap.
+
 .. note::
 
     Sitemap configuration is included in the Starter pack's
@@ -44,11 +47,14 @@ Optional sitemap configuration
 ------------------------------
 
 Sphinx sitemap uses a configurable URL scheme to set language and version options
-for your documentation. Default configuration provided by the starter pack uses:
+for your documentation. If you have no languages and no versions in your URL, add
+the following to your `conf.py` file:
 
 .. code-block::
 
     sitemap_url_scheme = "{link}"
+
+Note that this is the default configuration provided by the starter pack.
 
 To add versioning, this can be done manually, or you can read the version from
 the RTD instance. To implement a manual version:

--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -35,7 +35,7 @@ configuration file. For example, in :file:`docs/conf.py`:
 
     html_baseurl = 'https://canonical-starter-pack.readthedocs-hosted.com/'
 
-Make sure to include the trailing slash (`/`) to avoid errors in the concatenated
+Make sure to include the trailing slash (``/``) to avoid errors in the concatenated
 URLs in the sitemap.
 
 .. note::

--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -48,7 +48,7 @@ Optional sitemap configuration
 
 Sphinx sitemap uses a configurable URL scheme to set language and version options
 for your documentation. If you have no languages and no versions in your URL, add
-the following to your `conf.py` file:
+the following to your ``conf.py`` file:
 
 .. code-block::
 


### PR DESCRIPTION
When following the instructions to implement the sitemap, I ran into a
couple of places that confused me. I have added some clarification to those
places in the doc.

- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----
