### PR TITLE
fix: branch name in update script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # sphinx-docs-starter-pack changelog
 
+## 1.1.1
+
+* Fixes the download branch name in the update script.
+
+### Changed
+
+* `docs/.sphinx/update_sp.py` [#397](https://github.com/canonical/sphinx-docs-starter-pack/pull/397)
+
 ## 1.1.0
 
 * Adds sitemap support.

--- a/docs/.sphinx/update_sp.py
+++ b/docs/.sphinx/update_sp.py
@@ -23,7 +23,7 @@ SPHINX_UPDATE_DIR = os.path.join(SPHINX_DIR, "update")
 GITHUB_REPO = "canonical/sphinx-docs-starter-pack"
 GITHUB_API_BASE = f"https://api.github.com/repos/{GITHUB_REPO}"
 GITHUB_API_SPHINX_DIR = f"{GITHUB_API_BASE}/contents/docs/.sphinx"
-GITHUB_RAW_BASE = f"https://raw.githubusercontent.com/{GITHUB_REPO}/check-log"
+GITHUB_RAW_BASE = f"https://raw.githubusercontent.com/{GITHUB_REPO}/main"
 
 TIMEOUT = 10  # seconds
 


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?

-----

The update script didn't seem to be downloading the latest files, I think because the branch name wasn't set to `main`. This PR fixes that.