### PR TITLE
fix: remove references to obsolete docs/content/ directory

### DIFF
--- a/docs/how-to/edit.rst
+++ b/docs/how-to/edit.rst
@@ -3,30 +3,29 @@
 Edit content
 ============
 
-The landing page is stored in the :file:`docs/index.rst` file 
-while the rest of the pages are stored in the :file:`docs/content/` folder by default.
+The landing page is stored in the :file:`docs/index.rst` file by default.
 
 The Navigation Menu structure is set by ``.. toctree::`` directives. These directives define the hierarchy of included content throughout the documentation.
-The :file:`index.rst` page's ``toctree`` block contains the top level Navigation Menu.
+The :file:`index.rst` page's ``toctree`` block contains the top level Navigation Menu, default to the `Diátaxis`_ documentation structure.
 
 To add a new page to the documentation:    
 
-1. Create a new file in the `docs/content` folder. For example, to create the **Reference** page, create a document called :file:`reference.rst`, insert the following |RST|-formatted heading ``Reference`` at the beginning, and then save the file:
+1. Create a new file in the `docs/` folder. For example, to create a new **Reference** page, create a document under `docs/reference/` directory called :file:`settings.rst`, insert the following |RST|-formatted heading ``Settings`` at the beginning, and then save the file:
 
    .. code-block:: rest
       :caption: reStructuredText title example
 
-         Reference
-         =========
+         Settings
+         ========
 
-   If you prefer to use Markdown (MyST) syntax instead of |RST|, you can create a Markdown file. For example, :file:`reference.md` file with the following Markdown-formatted heading at the beginning:
+   If you prefer to use Markdown (MyST) syntax instead of |RST|, you can create a Markdown file. For example, :file:`settings.md` file with the following Markdown-formatted heading at the beginning:
 
    .. code-block:: markdown
       :caption: Markdown title example
          
-         # Reference
+         # Settings
 
-2. Add the new page to the Navigation Menu: open the :file:`index.rst` file or another file where you want to nest the new page; at the bottom of the file, locate the ``toctree`` directive and add a properly indented line containing the path (without a file extension) to the new file created in the first step. For example, ``content/reference``.
+2. Add the new page to the Navigation Menu: open the :file:`docs/reference/index.rst` file or another file where you want to nest the new page; at the bottom of the file, locate the ``toctree`` directive and add a properly indented line containing the relative path (without a file extension) to the new file created in the first step. For example, ``settings``.
 
    The ``toctree`` block will now look like this:
 
@@ -35,15 +34,12 @@ To add a new page to the documentation:
          .. toctree::
             :hidden:
             :maxdepth: 2
-         
-            Set up the documentation <set-up>
-            customise
-            rtd
-            update
-            automatic_checks
-            contributing
-            reference
+
+            Documentation checks <automatic_checks>
+            style-guide
+            style-guide-myst
+            settings
 
 The documentation will now show the new page added to the navigation when rebuilt.
 
-By default, the page's title (the first heading in the file) is used for the Navigation Menu entry. You can overwrite a name of a Menu element by specifying it explicitly in the ``toctree`` block, for example: `Reference </content/reference>`.
+By default, the page's title (the first heading in the file) is used for the Navigation Menu entry. You can overwrite a name of a Menu element by specifying it explicitly in the ``toctree`` block, for example: ``Reference </reference/index>``.

--- a/docs/how-to/migrate-from-pre-extension.rst
+++ b/docs/how-to/migrate-from-pre-extension.rst
@@ -82,7 +82,7 @@ If your project requires additional extensions beyond the default list, add the 
 Documentation source files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Remove the starter pack's documentation files (``index.rst`` and any files in the ``docs/content/*`` sub-directory).
+1. Remove the starter pack's documentation files (``index.rst`` and any files in the ``docs/**/*`` sub-directory).
 
 2. Copy all documentation source files from your original project to the new project, keeping their original structure. These file may include but are not limited to:
 

--- a/docs/tutorial/set-up.rst
+++ b/docs/tutorial/set-up.rst
@@ -36,7 +36,7 @@ This creates and activates a virtual environment in :file:`docs/.sphinx/venv`, b
 
 The server watches the source files, including :file:`docs/conf.py`, and rebuilds automatically on changes.
 
-The landing page is :file:`docs/index.rst`. Other pages are under :file:`docs/content`.
+The landing page is :file:`docs/index.rst`. Other pages are under one of the sub-directories under :file:`docs/`.
 
 
 Configure settings


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----

The `docs/content` folder has been removed from the repository, replaced by the diataxis folders under `docs/`. This PR:
- removed the obsolete references to the `docs/content` folder to reflect the new structure
- changed the example page from `docs/reference.rst` to `docs/reference/settings.rst` 