### PR TITLE
Add GitHub workflow for checking Contributor Licence Agreement

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,10 @@
+# This workflow checks if the contributor has signed the Canonical Contributor Licence Agreement (CLA)
+name: Canonical Contributor Licence Agreement check
+on: [pull_request]
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v2

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ This directory contains files used for documentation build checks via GitHub's C
 
 The file `test-starter-pack.yml` tests the functionality of the starter pack project.
 
+## Contributing
+
+We welcome contributions to this project! If you have suggestions, bug fixes, or improvements, please open an issue or submit a pull request.
+
+Please read and sign our [Contributor Licence Agreement (CLA)] before submitting any changes. The agreement grants Canonical permission to use your contributions. The author of a change remains the copyright owner of their code (no copyright assignment occurs).
+
 <!--Links-->
 
 [Sphinx]: https://www.sphinx-doc.org/
+[Contributor Licence Agreement (CLA)]: https://ubuntu.com/legal/contributors


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----

* add GitHub action from  [canonical/has-signed-canonical-cla](https://www.github.com/canonical/has-signed-canonical-cla) 
* add the CLA requirement in README