### PR TITLE
docs: add lastmod configuration for sphinx-sitemap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,9 +188,13 @@ if 'READTHEDOCS_VERSION' in os.environ:
 else:
     sitemap_url_scheme = 'MANUAL/{link}'
 
+# Include `lastmod` dates in the sitemap:
+
 sitemap_show_lastmod = True
 
+#######################
 # Template and asset locations
+#######################
 
 #html_static_path = ["_static"]
 #templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,8 @@ if 'READTHEDOCS_VERSION' in os.environ:
 else:
     sitemap_url_scheme = 'MANUAL/{link}'
 
+sitemap_show_lastmod = True
+
 # Template and asset locations
 
 #html_static_path = ["_static"]

--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -97,8 +97,7 @@ To read from the provided RTD environment variable::
 -------------------------
 
 As of version 2.7.0, the sitemap extension supports adding a ``lastmod`` date.
-Enabling this is done through the ``sitemap_show_lastmod`` key in your configuration
-file::
+Make sure that your configuration file has::
 
     sitemap_show_lastmod = True
 

--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -93,10 +93,10 @@ To read from the provided RTD environment variable::
     `sitemap name <https://sphinx-sitemap.readthedocs.io/en/latest/advanced-configuration.html#changing-the-filename>`_
     and a custom ``robots.txt`` pointing to it.
 
-Lastmod configuration
----------------------
+``lastmod`` configuration
+-------------------------
 
-As of version 2.7.0, the sitemap extension supports adding a `lastmod` date.
+As of version 2.7.0, the sitemap extension supports adding a ``lastmod`` date.
 Enabling this is done through the ``sitemap_show_lastmod`` key in your configuration
 file::
 

--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -49,8 +49,8 @@ URLs in the sitemap.
     Sitemap configuration is included in the Starter pack's
     `default configuration file <https://github.com/canonical/sphinx-docs-starter-pack/blob/a489ae041f6cebb7948fdf21b996e8c67d636a83/docs/conf.py#L176>`_.
 
-Optional sitemap configuration
-------------------------------
+URL configuration
+-----------------
 
 Sphinx sitemap uses a configurable URL scheme to set language and version options
 for your documentation. If you have no languages and no versions in your URL, add
@@ -92,6 +92,15 @@ To read from the provided RTD environment variable::
     This is a known bug. The only current workaround is to use a different
     `sitemap name <https://sphinx-sitemap.readthedocs.io/en/latest/advanced-configuration.html#changing-the-filename>`_
     and a custom ``robots.txt`` pointing to it.
+
+Lastmod configuration
+---------------------
+
+As of version 2.7.0, the sitemap extension supports adding a `lastmod` date.
+Enabling this is done through the ``sitemap_show_lastmod`` key in your configuration
+file::
+
+    sitemap_show_lastmod = True
 
 Validating your sitemap
 -----------------------
@@ -148,24 +157,20 @@ For instance, using the starter pack as an example, with three versions
 
     .. code-block::
 
-            <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-            <url>
+            <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <sitemap>
             <loc>https://canonical-starter-pack.readthedocs-hosted.com/latest/sitemap.xml</loc>
-            <lastmod>2025-04-30</lastmod>
-            </url>
-            <url>
+            </sitemap>
+            <sitemap>
             <loc>https://canonical-starter-pack.readthedocs-hosted.com/3.0/sitemap.xml</loc>
-            <lastmod>2025-04-30</lastmod>
-            </url>
-            <url>
+            </sitemap>
+            <sitemap>
             <loc>https://canonical-starter-pack.readthedocs-hosted.com/2.0/sitemap.xml</loc>
-            <lastmod>2025-04-30</lastmod>
-            </url>
-            <url>
+            </sitemap>
+            <sitemap>
             <loc>https://canonical-starter-pack.readthedocs-hosted.com/1.0/sitemap.xml</loc>
-            <lastmod>2025-04-30</lastmod>
-            </url>
-            </urlset>
+            </sitemap>
+            </sitemapindex>
 
 4.  Add ``robots.txt`` and ``sitemapindex.xml`` to your configuration file:
 


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----

Adds documentation for adding a `lastmod` date to the sitemap generated by sphinx-sitemaps.
Fixes sitemapindex construction.