### PR TITLE
Reference an existing variable

### DIFF
--- a/docs/.sphinx/update_sp.py
+++ b/docs/.sphinx/update_sp.py
@@ -113,7 +113,7 @@ def main():
 
             new_requirements = requirements - local_reqs
 
-            for req in requirements - local_reqs:
+            for req in new_requirements:
                 logging.debug(f"{req} not found in local requirements.txt")
 
             for req in requirements & local_reqs:


### PR DESCRIPTION
### Minor fix

The differences have already been calculated and saved in the `new_requirements` variable. It's more efficient to reference the variable rather than recalculating the differences again. 
