### PR TITLE
Remove confusing statement on sitemap config

### DIFF
--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -60,8 +60,6 @@ the following to your ``conf.py`` file:
 
     sitemap_url_scheme = "{link}"
 
-Note that this is the default configuration provided by the starter pack.
-
 To add versioning, this can be done manually, or you can read the version from
 the RTD instance. To implement a manual version:
 


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
   - n/a
- [x] Have you updated the documentation for this change?

-----

This removes a confusing statement that suggested the SP provided some default sitemap config.

@SecondSkoll, given the doc includes a note (a few lines above this) that says _Sitemap configuration is included in the Starter pack's default configuration file_, I believe there's no need to clarify this confusing statement -- instead, it can be just removed.