### PR TITLE
docs: fix info about setting RTD key as GitHub deploy key

### DIFF
--- a/docs/how-to/rtd.rst
+++ b/docs/how-to/rtd.rst
@@ -26,7 +26,7 @@ After this initial setup, your documentation should build successfully if your p
 If you get any errors, check the build log for indications on what the problem is.
 
 If your project was imported from a private repository, your initial build will fail because Read the Docs won't have access to clone the repository.
-You need to copy your project's private key from Read the Docs and add it as a deploy key to the repository, then re-run the build in Read the Docs.
+You need to copy your project's public key from Read the Docs and add it as a deploy key to the repository, then re-run the build in Read the Docs.
 
 Configure the webhook
 ---------------------


### PR DESCRIPTION
In [Set up Read the Docs](https://canonical-starter-pack.readthedocs-hosted.com/latest/how-to/rtd/) we say:

> If your project was imported from a private repository, your initial build will fail because Read the Docs won't have access to clone the repository. You need to copy your project's private key from Read the Docs and add it as a deploy key to the repository, then re-run the build in Read the Docs.

But it's not the private key that needs to be copied, it's the public key. This PR fixes the doc.