### PR TITLE
Ensure update_sp.py is executable from any directory not just docs/

### DIFF
--- a/docs/.sphinx/update_sp.py
+++ b/docs/.sphinx/update_sp.py
@@ -208,7 +208,7 @@ def update_static_files():
     # Writes return value for parent function
     if new_file_list != []:
         # Provides more information on new files
-        with open("NEWFILES.txt", "w") as f:
+        with open(f"{SPHINX_DIR}/NEWFILES.txt", "w") as f:
             for entry in new_file_list:
                 f.write(f"{entry}\n")
         logging.debug("Some downloaded files are new")


### PR DESCRIPTION
The script was initially only able to run when executed from the `docs/` directory. Hence, the error @rkratky was experiencing in this issue #420.

`SPHINX_DIR = os.path.join(os.getcwd(), ".sphinx")`

`os.getcwd()` retrieves the current working directory and joins `.sphinx` to it. This makes it only executable from the `docs/` directory. A more efficient way is to make it executable from any directory.

So, I opted to use `os.path.dirname(__file__)` to retrieve the file path to the `update_sp.py` script. `os.path.abspath` ensures that the path joined later in the script uses the full directory from root, where the script is stored locally.