### PR TITLE
Add warning to set-up-automated-testing.rst

### DIFF
--- a/docs/tutorial/set-up-automated-testing.rst
+++ b/docs/tutorial/set-up-automated-testing.rst
@@ -19,6 +19,12 @@ your tutorial uses the same commands that Spread is testing.
 * `Multipass <https://multipass.run/install>`_ installed on your machine 
 * `Spread <https://github.com/canonical/spread>`_ installed on your machine
 
+.. warning::
+
+    Spread requires elevated permissions to run as root, and this tutorial will
+    not work if Spread is installed as a snap. Use the Go install method
+    recommended in the Spread README to install Spread.
+
 **What you’ll do**
 
 * Create a "Hello, world" Spread test called ``example_tutorial``


### PR DESCRIPTION
Spread installed from a snap might not have the correct permissions to run as root, which is required to use the Multipass backend in this tutorial. Therefore, the tutorial needs to be updated warning the user to install Spread via ``go install``.

- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [X] Have you updated the documentation for this change?

-----
