### PR TITLE
Use long parameter for 'fail on warning'

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -82,7 +82,7 @@ run: install
 
 # Does not depend on $(BUILDDIR) to rebuild properly at every run.
 html: install
-	. $(VENV); $(SPHINXBUILD) -W --keep-going -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
+	. $(VENV); $(SPHINXBUILD) --fail-on-warning --keep-going -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
 
 epub: install
 	. $(VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)

--- a/docs/how-to/customise.rst
+++ b/docs/how-to/customise.rst
@@ -183,3 +183,9 @@ The following links can help you with additional configuration:
 - `Furo documentation`_ (Furo is the Sphinx theme we use as our base)
 
 If you need additional Python packages for any custom processing you do in your documentation, add them to the :file:`.sphinx/requirements.txt` file.
+
+Disable failure on warning
+--------------------------
+
+The docs build (``make html``) is, by default, set to fail when a warning (``WARNING`` in the build log) is encountered. To disable this setting, remove the ``--failure-on-warning`` option from the command specified in the ``html`` target in the ``Makefile``.
+


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

Neither necessary as this isn't a functionality-changing modification.

-----

Using the long format makes the Makefile easier to read and grep.