### PR TITLE
chore: add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # Development reviewers
 # Adjust this once we establish a Sphinx development team.
-* @akcano @dwilding @medubelko @minaelee @rkratky @SecondSkoll @tangmm
+* @akcano @dwilding @medubelko @minaelee @rkratky @SecondSkoll @tang-mm
 
 # Changes to CODEOWNERS must be reviewed by admins
 /.github/CODEOWNERS @SecondSkoll

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Codeowners for this repository.
+# Guidance and syntax is covered in
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# 
+# Important: The last match takes precedence.
+
+# Development reviewers
+# Adjust this once we establish a Sphinx development team.
+* @akcano @dwilding @medubelko @minaelee @rkratky @SecondSkoll @tangmm
+
+# Changes to CODEOWNERS must be reviewed by admins
+/.github/CODEOWNERS @SecondSkoll
+
+# Doc reviewers
+# /docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Added
 
 * `docs/.sphinx/metrics/build_metrics.py` [#373](https://github.com/canonical/sphinx-docs-starter-pack/pull/373)
-* `.github/CODEOWNERS` [#438](https://github.com/canonical/sphinx-docs-starter-pack/pull/439)
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 * `docs/.sphinx/metrics/build_metrics.py` [#373](https://github.com/canonical/sphinx-docs-starter-pack/pull/373)
+* `.github/CODEOWNERS` [#438](https://github.com/canonical/sphinx-docs-starter-pack/pull/439)
 
 ## Changed
 


### PR DESCRIPTION
For #438.

Enumerate individual reviewers. Later, we can add a Sphinx development team, once we've established one.

I've added our most prominent reviewers to review this to check for consent.

**If you'd prefer not to receive review requests on PRs automatically**, please say so, and I'll remove you from the list. :)

---
~~- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?~~
~~- [ ] Have you updated the documentation for this change?~~
