### PR TITLE
Update Open Graph image URL in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ ogp_site_name = project
 #
 # TODO: To customise the preview image, update as needed.
 
-ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg"
+ogp_image = "https://assets.ubuntu.com/v1/cc828679-docs_illustration.svg"
 
 
 # Product favicon; shown in bookmarks, browser tabs, etc.


### PR DESCRIPTION
The preview image being used was an old one, and the design team has suggested the use of this one instead. (MM conversation for reference: https://chat.canonical.com/canonical/pl/wb319fbzotrd7ryj4tj6941i3y)

- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
