### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/check-removed-urls.yml
+++ b/.github/workflows/check-removed-urls.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # This implicitly gets the PR branch. Making it explicit causes problems
           # with private forks, but it is equivalent to the following:
@@ -18,13 +18,13 @@ jobs:
           fetch-depth: 0
           path: compare
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           fetch-depth: 0
           path: base
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
       - name: Build docs
         run: |
           for dir in compare base; do

--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -16,7 +16,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Create venv

--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install dependencies
       run: |
         set -ex
         sudo apt-get --fix-missing update
-        sudo apt -y install \
+        sudo apt-get -y install \
           cargo \
           libpython3-dev \
           libxml2-dev \

--- a/.github/workflows/test-starter-pack.yml
+++ b/.github/workflows/test-starter-pack.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Build docs


### PR DESCRIPTION
Some updates to the workflows based on feedback I received from my engineering team during a RTD project setup:
* `actions/checkout@v4` --> `actions/checkout@v5`
* `actions/setup-python@v5` --> `actions/setup-python@v6`
* Changed an `apt` to `apt-get`

- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
I don't think the documentation needs to be updated based on these changes.
