### PR TITLE
Details about sphinx-terminal

### DIFF
--- a/docs/reference/myst-syntax-reference.md
+++ b/docs/reference/myst-syntax-reference.md
@@ -198,6 +198,8 @@ To customize the prompt (`user@host:~$` by default), specify any of the followin
 * `:host:`
 * `:dir:`
 
+To add a button that copies the command specified in `:input:`, include the `:copy:` option.
+
 To make the terminal scroll horizontally instead of wrapping long lines, include the `:scroll:` option.
 
 For more details, refer to the [`sphinx-terminal` README](https://github.com/canonical/sphinx-terminal/blob/main/README.md).

--- a/docs/reference/rst-syntax-reference.rst
+++ b/docs/reference/rst-syntax-reference.rst
@@ -179,6 +179,8 @@ To customize the prompt (``user@host:~$`` by default), specify any of the follow
 * ``:host:``
 * ``:dir:``
 
+To add a button that copies the command specified in ``:input:``, include the ``:copy:`` option.
+
 To make the terminal scroll horizontally instead of wrapping long lines, include the ``:scroll:`` option.
 
 For more details, refer to the `sphinx-terminal README <https://github.com/canonical/sphinx-terminal/blob/main/README.md>`_.


### PR DESCRIPTION
Some useful options for the `sphinx-terminal` extension were missing. I've added one (`:dir:`) and linked the upstream documentation for the rest.
