### PR TITLE
fix(docs): add version to style guide redirects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,10 +225,10 @@ sitemap_excludes = [
 #       the sphinx_reredirects extension will be disabled.
 
 redirects = {
-    'reference/doc-cheat-sheet-myst/': '/latest/reference/myst-syntax-reference',
-    'reference/doc-cheat-sheet/': '/latest/reference/rst-syntax-reference',
-    'reference/style-guide-myst/': '/latest/reference/myst-syntax-reference',
-    'reference/style-guide/': '/latest/reference/rst-syntax-reference',
+    'reference/doc-cheat-sheet-myst/': '../myst-syntax-reference',
+    'reference/doc-cheat-sheet/': '../rst-syntax-reference',
+    'reference/style-guide-myst/': '../myst-syntax-reference',
+    'reference/style-guide/': '../rst-syntax-reference',
 }
 
 


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [X] Have you updated the documentation for this change?

-----

The current docs redirects specify an absolute path with no version, resulting in a 404 ([example](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/)).