### PR TITLE
docs: remove contributing template from index

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -18,7 +18,6 @@ Set up, configure, upgrade, and customize your project to keep it organized and 
    customise-pdf
    migrate-from-pre-extension
    update
-   contributing
    troubleshoot-issues
 
 Optional features and workflows


### PR DESCRIPTION
~~- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?~~
~~- [ ] Have you updated the documentation for this change?~~

-----

Removes the contributing guide template from the how-to index

While I see the value in offering a template guide for new docs projects, it shouldn't be rendered in the docs. I assume this guide wasn't meant to be indexed, as it was denoted as an orphan page.