### PR TITLE
docs: fix broken link and update redirects

### DIFF
--- a/docs/how-to/contributing-myst.md
+++ b/docs/how-to/contributing-myst.md
@@ -17,7 +17,7 @@ The guidelines below will help keep your contributions effective and meaningful.
 
 ## Code of conduct
 
-When contributing, you must abide by the [Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct).
+When contributing, you must abide by the [Ubuntu Code of Conduct](https://ubuntu.com/community/docs/ethos/code-of-conduct).
 
 ## Licence and copyright
 
@@ -25,7 +25,7 @@ When contributing, you must abide by the [Ubuntu Code of Conduct](https://ubuntu
 
 By default, all contributions to ACME are made under the AGPLv3 licence. See the [licence](https://github.com/canonical/ACME/blob/main/COPYING) in the ACME GitHub repository for details.
 
-All contributors must sign the [Canonical contributor licence agreement](https://ubuntu.com/legal/contributors), which grants Canonical permission to use the contributions. The author of a change remains the copyright owner of their code (no copyright assignment occurs).
+All contributors must sign the [Canonical contributor licence agreement](https://canonical.com/legal/contributors), which grants Canonical permission to use the contributions. The author of a change remains the copyright owner of their code (no copyright assignment occurs).
 
 ## Releases and versions
 
@@ -201,9 +201,9 @@ TODO: test command 2
 
 ## Documentation
 
-ACME's documentation is stored in the `DOCDIR` directory of the repository. It is based on the [Canonical starter pack](https://canonical-starter-pack.readthedocs-hosted.com/latest/) and hosted on [Read the Docs](https://about.readthedocs.com/).
+ACME's documentation is stored in the `DOCDIR` directory of the repository. It is based on the [Canonical starter pack](https://canonical-starter-pack.readthedocs-hosted.com/) and hosted on [Read the Docs](https://about.readthedocs.com/).
 
-For general guidance, refer to the [starter pack guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/).
+For general guidance, refer to the [starter pack guide](https://canonical-starter-pack.readthedocs-hosted.com/).
 
 For syntax help and guidelines, refer to the syntax guides contained in the [rST](project:#style-guide) and [MyST](project:#myst_style_guide) syntax guides.
 

--- a/docs/how-to/contributing.rst
+++ b/docs/how-to/contributing.rst
@@ -30,7 +30,7 @@ Code of conduct
 ---------------
 
 When contributing, you must abide by the
-`Ubuntu Code of Conduct <https://ubuntu.com/community/ethos/code-of-conduct>`_.
+`Ubuntu Code of Conduct <https://ubuntu.com/community/docs/ethos/code-of-conduct>`_.
 
 
 Licence and copyright
@@ -43,7 +43,7 @@ See the `licence <https://github.com/canonical/ACME/blob/main/COPYING>`_
 in the ACME GitHub repository for details.
 
 All contributors must sign the `Canonical contributor licence agreement
-<https://ubuntu.com/legal/contributors>`_,
+<https://canonical.com/legal/contributors>`_,
 which grants Canonical permission to use the contributions.
 The author of a change remains the copyright owner of their code
 (no copyright assignment occurs).
@@ -295,7 +295,7 @@ Documentation
 
 ACME's documentation is stored in the ``DOCDIR`` directory of the repository.
 It is based on the `Canonical starter pack
-<https://canonical-starter-pack.readthedocs-hosted.com/latest/>`_
+<https://canonical-starter-pack.readthedocs-hosted.com/>`_
 and hosted on `Read the Docs <https://about.readthedocs.com/>`_.
 
 For syntax help and guidelines,

--- a/docs/how-to/migrate-from-pre-extension.rst
+++ b/docs/how-to/migrate-from-pre-extension.rst
@@ -13,7 +13,7 @@ To ensure a smooth migration, update your documentation project to use the last 
 
 You can find the release tag and branch for this version in the following links:
 
-* `pre-extension branch <https://github.com/canonical/sphinx-docs-starter-pack/blob/pre-extension>`_
+* `pre-extension branch <https://github.com/canonical/sphinx-docs-starter-pack/tree/pre-extension>`_
 * `pre-extension release tag <https://github.com/canonical/sphinx-docs-starter-pack/releases/tag/pre-extension>`_
 
 

--- a/docs/reference/myst-syntax-reference.md
+++ b/docs/reference/myst-syntax-reference.md
@@ -17,7 +17,7 @@ The documentation files use a mixture of [Markdown](https://commonmark.org/) and
 See the following sections for syntax help and conventions.
 
 ```{note}
-This guide assumes that you are using the [Sphinx documentation starter pack](https://github.com/canonical/starter-pack).
+This guide assumes that you are using the [Sphinx documentation starter pack](https://github.com/canonical/sphinx-docs-starter-pack).
 Some of the mentioned syntax requires Sphinx extensions (which are enabled in the starter pack).
 ```
 
@@ -649,7 +649,7 @@ Adhere to the following conventions:
 
 - For local pictures, start the path with `/` (for example, `/images/image.png`).
 - Use `PNG` format for screenshots and `SVG` format for graphics.
-- See [Five golden rules for compliant alt text](https://abilitynet.org.uk/news-blogs/five-golden-rules-compliant-alt-text) for information about how to word the alt text.
+- See [Five golden rules for compliant alt text](https://abilitynet.org.uk/resources/digital-accessibility/five-golden-rules-compliant-alt-text) for information about how to word the alt text.
 
 ## Reuse
 

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -8,12 +8,12 @@
 .. _Example product documentation: https://canonical-example-product-documentation.readthedocs-hosted.com/
 .. _Example product documentation repository: https://github.com/canonical/example-product-documentation
 .. _`file-wide metadata`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html
-.. _Five golden rules for compliant alt text: https://abilitynet.org.uk/news-blogs/five-golden-rules-compliant-alt-text
+.. _Five golden rules for compliant alt text: https://abilitynet.org.uk/resources/digital-accessibility/five-golden-rules-compliant-alt-text
 .. _`Furo documentation`: https://pradyunsg.me/furo/quickstart/
 .. _grid tables: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#grid-tables
 .. _`Hiding Contents sidebar`: https://pradyunsg.me/furo/customisation/toc/
 .. _How to connect your Read the Docs account to your Git provider: https://docs.readthedocs.com/platform/stable/guides/connecting-git-account.html
-.. _How to manually configure a Git repository integration: https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html
+.. _How to manually configure a Git repository integration: https://docs.readthedocs.com/platform/stable/guides/setup/git-repo-manual.html
 .. _How to publish documentation on Read the Docs: https://library.canonical.com/documentation/publish-on-read-the-docs
 .. _Level AA conformance: https://www.w3.org/WAI/WCAG2AA-Conformance
 .. _list tables: https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table
@@ -31,7 +31,7 @@
 .. _Sphinx DataTables: https://sharm294.github.io/sphinx-datatables/
 .. _Sphinx design: https://sphinx-design.readthedocs.io/en/latest/
 .. _Sphinx documentation starter pack:
-.. _Sphinx documentation starter pack repository: https://github.com/canonical/starter-pack
+.. _Sphinx documentation starter pack repository: https://github.com/canonical/sphinx-docs-starter-pack
 .. _Sphinx documentation starter pack documentation: https://canonical-starter-pack.readthedocs-hosted.com/
 .. _`Sphinx extensions`: https://www.sphinx-doc.org/en/master/usage/extensions/index.html
 .. _Sphinx tabs: https://sphinx-tabs.readthedocs.io/en/latest/

--- a/docs/tutorial/set-up-automated-testing.rst
+++ b/docs/tutorial/set-up-automated-testing.rst
@@ -16,7 +16,7 @@ your tutorial uses the same commands that Spread is testing.
 
 **What you'll need**
 
-* `Multipass <https://multipass.run/install>`_ installed on your machine 
+* `Multipass <https://documentation.ubuntu.com/multipass/latest/how-to-guides/install-multipass/>`_ installed on your machine 
 * `Spread <https://github.com/canonical/spread>`_ installed on your machine
 
 .. warning::


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----

This PR is mainly intended to fix a broken link where the starter pack "latest" path should now point to "stable".
It also includes some updates to links to minimize the redirects to keep the `make linkcheck` output cleaner.
