### PR TITLE
Update sphinx-related-links to 0.1.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ sphinxext-opengraph
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
-sphinx-related-links>=0.1.1
+sphinx-related-links>=0.1.2
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2
 sphinx-ubuntu-images>=0.1.0


### PR DESCRIPTION
- [N/A] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [N/A] Have you updated the documentation for this change?

-----

This introduces the fix suggested by @minaelee in canonical/sphinx-related-links#17 to address the bug where setting `discourse_prefix` to a `dict` caused an error.