### PR TITLE
fix: pin myst-parser package version to 4.0 to avoid conflicts

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx>=0.5.1
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
+myst-parser~=4.0    # v5.0.0 causes version conflicts
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
`myst-parser` released [5.0.0](https://pypi.org/project/myst-parser/5.0.0/) today and caused failures when installing documentation requirements (Python >=3.11):

Example error log:
```bash
...
Collecting sphinx-tabs (from -r docs/requirements.txt (line 10))
  Downloading sphinx_tabs-3.4.5-py3-none-any.whl.metadata (6.3 kB)
  Downloading sphinx_tabs-3.4.4-py3-none-any.whl.metadata (6.3 kB)
INFO: pip is looking at multiple versions of sphinx-tabs to determine which version is compatible with other requirements. This could take a while.
...
Collecting Sphinx>=7.1.2 (from canonical-sphinx>=0.5.1->-r docs/requirements.txt (line 2))
  Downloading sphinx-8.2.2-py3-none-any.whl.metadata (7.0 kB)
  Downloading sphinx-8.2.1-py3-none-any.whl.metadata (7.0 kB)
  Downloading sphinx-8.2.0-py3-none-any.whl.metadata (7.0 kB)
  Downloading sphinx-8.1.3-py3-none-any.whl.metadata (6.4 kB)

error: resolution-too-deep
× Dependency resolution exceeded maximum depth
╰─> Pip cannot resolve the current dependencies as the dependency graph is too complex for pip to solve efficiently.

hint: Try adding lower bounds to constrain your dependencies, for example: 'package>=2.0.0' instead of just 'package'.
Link: https://pip.pypa.io/en/stable/topics/dependency-resolution/#handling-resolution-too-deep-errors
```