### PR TITLE
fix: resolve pymarkdown linting exclude path issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Upcoming
 
 * Fix exclude paths issue for pymarkdown introduced in 0.9.35 and pin version.
-* Remove scripts and references to unused HTML metrics.
+* Add `install` dependency to `pymarkdownlnt-install` make target and use VENVDIR variable.
+* Remove scripts and references o unused HTML metrics.
 * Pin myst-parser package version to 4.0 to avoid conflicts.
 
 ### Changed

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -71,8 +71,8 @@ pa11y-install:
 			npm install --prefix $(SPHINXDIR) pa11y; \
 		}
 
-pymarkdownlnt-install:
-	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/pymarkdown || pip install pymarkdownlnt==0.9.35
+pymarkdownlnt-install: install
+	@. $(VENV); test -d $(VENVDIR)/lib/python*/site-packages/pymarkdown || pip install pymarkdownlnt==0.9.35
 
 install: $(VENVDIR)
 


### PR DESCRIPTION
Fixes an issue introduced in pymarkdown 0.9.35 where the exclude paths need to be specified without the leading './' and pins to 0.9.35 to avoid future breaking changes.

A secondary commit also adds the `install` dependency to the `pymarkdownlnt-install` make target and substitutes `$(VENVDIR)` for `$(SPHINXDIR)/venv/` in the make command.

Fixes #509.

---
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change? _unneeded_
