### PR TITLE
docs: use github template instead of git clone

### DIFF
--- a/docs/tutorial/set-up.rst
+++ b/docs/tutorial/set-up.rst
@@ -11,7 +11,9 @@ This page contains a short guide on how to set up and use the starter pack.
 Copy the starter pack
 =====================
 
-If you're starting a new project, clone the `starter pack repository <https://github.com/canonical/sphinx-docs-starter-pack>`_ and begin your project from there.
+If you're starting a new project, `copy the starter pack as a template repository <https://github.com/new?template_name=sphinx-docs-starter-pack&template_owner=canonical>`__.
+
+If you're creating documentation for a Canonical project, set the owner to **canonical**.
 
 If you're adding documentation to an existing software project, copy the following files from the starter pack repository into your project:
 


### PR DESCRIPTION
Revise tutorial to instruct users to use the GitHub template feature instead of cloning the repository, as this is our expectation.

---
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes? _no non-documentation file changes_
- [x] Have you updated the documentation for this change? _change is only a documentation update_

