### PR TITLE
fix: ignore linkcheck for sourceforge and example.com

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,7 +244,10 @@ redirects = {
 
 linkcheck_ignore = [
     "http://127.0.0.1:8000",
-    "https://github.com/canonical/ACME/*"
+    "https://github.com/canonical/ACME/*",
+    "https://example.com",
+    # SourceForge domains often block linkcheck
+    r"https://.*\.sourceforge\.(net|io)/.*",
     ]
 
 


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes? _not needed_
- [ ] Have you updated the documentation for this change? _not needed_

-----

Links to docutils.sourgeforce.io and example.com currently failing linkcheck due to domain protections while being accessible from the browser. This PR updates `linkcheck_ignore` to bypass this, ignoring all sourceforge.io/com links because I've seen the same behavior repeatedly from any links to those domains, not just docutils.