### PR TITLE
chore(deps): constrain canonical-sphinx dependency to ~=0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Remove or replace docs use of archived example product documentation site.
 * Revert the switch to a reusable `automatic-doc-checks.yml` workflow.
 * Add `-q` flag to linkchecker to only report errors or broken links.
+* Update dependency canonical-sphinx to 0.6.0 or higher.
 
 ### Changed
 
@@ -19,6 +20,7 @@
 * `docs/reference/rst-syntax-reference.rst` [#502](https://github.com/canonical/sphinx-docs-starter-pack/pull/502)
 * `.github/workflows/automatic-doc-checks.yml` [#514](https://github.com/canonical/sphinx-docs-starter-pack/pull/514)
 * `docs/Makefile` [#536](https://github.com/canonical/sphinx-docs-starter-pack/pull/536)
+* `docs/requirements.txt` [#543](https://github.com/canonical/sphinx-docs-starter-pack/pull/543)
 
 ## 1.4.1
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Canonical theme (still needed for Furo theme and custom templates)
-canonical-sphinx>=0.5.1
+canonical-sphinx~=0.6
 
 # Extensions previously auto-loaded by canonical-sphinx
 myst-parser~=4.0    # v5.0.0 causes version conflicts


### PR DESCRIPTION
Documentation will be provided in upcoming release notes.

---
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
~~- [ ] Have you updated the documentation for this change?~~
