### PR TITLE
Use double backticks for file names.

### DIFF
--- a/docs/how-to/update-starter-packs/new-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/new-starter-pack.rst
@@ -19,7 +19,7 @@ structure closely mirrors the starter pack's. Depending on your customizations,
 you may need to take extra steps when upgrading. 
 
 .. note::
-   If ``canonical-sphinx`` is not included under ``extensions`` in your `conf.py`, 
+   If ``canonical-sphinx`` is not included under ``extensions`` in your ``conf.py``, 
    your project is not on an extension-based starter-pack. Follow the guide on 
    :ref:`updating a legacy starter pack project <update-legacy-starter-pack>`.
 
@@ -51,20 +51,20 @@ cannot be overly prescriptive.
 
 ``conf.py``
 ~~~~~~~~~~~
-Rename your `conf.py` file to avoid overwriting it, and copy the starter pack's 
+Rename your ``conf.py`` file to avoid overwriting it, and copy the starter pack's 
 version to the same location. Use a graphical diff tool such as `Kompare <https://apps.kde.org/kompare/>`_
 or `meld <https://meldmerge.org/>`_ to compare the old and new file and make the 
 following changes:
 
--   Copy your standard project details to the new `conf.py` file. These include:
+-   Copy your standard project details to the new ``conf.py`` file. These include:
 
     -   Project and author names 
     -   Ignored links
     -   Social links, etc.
 
--   Verify that the `/static` and `/templates` directories are located at the locations
-    specified by `html_static_path` and `templates_path`, respectively, in the 
-    new `conf.py` file. These should not be inside the `/.sphinx` directory.
+-   Verify that the ``/static`` and ``/templates`` directories are located at the locations
+    specified by ``html_static_path`` and ``templates_path``, respectively, in the 
+    new ``conf.py`` file. These should not be inside the ``/.sphinx`` directory.
 
 For other customizations, consider need and compatibility before copying them to 
 the new file. If it's not obvious whether you should copy over a customization
@@ -72,8 +72,8 @@ or include a new change, reach out to `Canonical's documentation team <https://m
 
 ``Makefile`` and ``.readthedocs.yaml``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Depending on the version of your project's starter pack, the new `Makefile` and `.readthedocs.yaml`
-files may have few or no changes. Apply the same approach you used for `conf.py` 
+Depending on the version of your project's starter pack, the new ``Makefile`` and ``.readthedocs.yaml``
+files may have few or no changes. Apply the same approach you used for ``conf.py`` 
 to merge your customizations into the new files. 
 
 If there are no project-specific customizations in your files but there are changes 
@@ -81,12 +81,12 @@ in the new ones, you can just overwrite your existing files with the new ones.
 
 Update the ``.sphinx`` directory
 --------------------------------
-In addition to the docs above, the `/.sphinx` directory is also likely to have some
+In addition to the docs above, the ``/.sphinx`` directory is also likely to have some
 changes in each upgrade. These files are not intended to be modified by users. 
 
 Unless you intentionally customized files in this directory, you can simply delete 
-your project's `/.sphinx` directory and replace it with the starter pack's. If there 
-are modifications in your project's `/.sphinx` directory, it is recommended that 
+your project's ``/.sphinx`` directory and replace it with the starter pack's. If there 
+are modifications in your project's ``/.sphinx`` directory, it is recommended that 
 they transfer them out.
 
 Review the remaining files
@@ -94,13 +94,13 @@ Review the remaining files
 Some files in the starter pack may be updated less frequently, but it's a good idea 
 to review them during each upgrade and determine if there are relevant changes:
 
--   Review `requirements.txt`: If there are any updates, and your project's file 
+-   Review ``requirements.txt``: If there are any updates, and your project's file 
     has no repository-specific requirements, you can overwrite the existing file 
     with the new one. If you added requirements based on your customizations be 
-    sure to include them, e.g., `sphinxext-rediraffe` if you use rediraffe to 
+    sure to include them, e.g., ``sphinxext-rediraffe`` if you use rediraffe to 
     handle redirects.
 
--   Review the workflows in the `/.github` directory: If there are changes in the 
+-   Review the workflows in the ``/.github`` directory: If there are changes in the 
     following workflows, replace the existing files with the new ones. The starter 
     pack will have other workflows as well, but you'll need to decide whether your 
     project needs them or not: 
@@ -110,7 +110,7 @@ to review them during each upgrade and determine if there are relevant changes:
     -   Check for removed URLs
     -   Markdown style check (only required for docs using markdown)
 
--   Review and transfer any necessary changes in the new `.gitignore` file to your 
+-   Review and transfer any necessary changes in the new ``.gitignore`` file to your 
     project.
 
 Build and test
@@ -125,7 +125,7 @@ the following commands and fix any errors reported:
 -   ``make spelling``
 -   ``make linkcheck``
 -   ``make woke``
--   ``make lint-md`` (if you included the `markdown-style-checks` workflow)
+-   ``make lint-md`` (if you included the ``markdown-style-checks`` workflow)
 
 Troubleshooting errors
 ----------------------
@@ -145,20 +145,20 @@ Clean up
 There may be files that need to be deleted after the upgrade such as starter-pack 
 specific files or files that have been replaced with newer versions: 
 
--   If you haven't done so already, delete the copies of `conf.py`, `Makefile`, and 
-    `/.readthedocs.yaml` that were renamed and replaced. 
+-   If you haven't done so already, delete the copies of ``conf.py``, ``Makefile``, and 
+    ``/.readthedocs.yaml`` that were renamed and replaced. 
 -   If you did not strictly follow this guide for this or previous upgrades, it's 
     possible that you have some starter pack-specific files in your project. 
     These files can be safely deleted: 
 
-    -   `.github/pull_request_template.md`
-    -   `.github/workflows/sphinx-python-dependency-build-checks.yml`
-    -   `.github/CODEOWNERS`
-    -   `.github/workflows/test-starter-pack.yml`
+    -   ``.github/pull_request_template.md``
+    -   ``.github/workflows/sphinx-python-dependency-build-checks.yml``
+    -   ``.github/CODEOWNERS``
+    -   ``.github/workflows/test-starter-pack.yml``
     
 -   These files can be deleted as long as they are not being used in your docs:
 
-    -   `docs/reuse/links.txt`
-    -   `docs/reuse/mermaid.txt`
-    -   `docs/reuse/substitutions.txt`
-    -   `docs/reuse/substitutions.yaml`
+    -   ``docs/reuse/links.txt``
+    -   ``docs/reuse/mermaid.txt``
+    -   ``docs/reuse/substitutions.txt``
+    -   ``docs/reuse/substitutions.yaml``


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
Change file names from single to double backticks in the new upgrade guide.