### PR TITLE
docs: update 'set up sphinx sitemaps'

### DIFF
--- a/docs/how-to/set-up-sitemaps.rst
+++ b/docs/how-to/set-up-sitemaps.rst
@@ -149,7 +149,7 @@ file, and point to the sitemap files of each of your documentation sets:
 Create a ``robots.txt`` file in the same directory as the configuration file.
 
 If necessary, block any paths you don't want crawled. Google describes how to do this in
-`How to write and submit a robost.txt file
+`How to write and submit a robots.txt file
 <https://developers.google.com/crawling/docs/robots-txt/create-robots-txt#create_rules>`__.
 
 At the end of ``robots.txt``, point to the future path of ``sitemapindex.xml``:


### PR DESCRIPTION
[According to Copilot](https://github.com/canonical/mir/pull/4771#discussion_r2932352555):

> `Disallow: # Allow everything` is not a valid way to comment in `robots.txt`; many crawlers will treat the value as a path, not a comment. If the intent is to allow everything, use an empty Disallow: line and put the comment on its own `# ...` line (or omit the directive entirely).

- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----
