### PR TITLE
feat: update default copyright and license settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 * `.github/workflows/check-removed-urls.yml` [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)
 * `.github/workflows/sphinx-python-dependency-build-checks.yml` [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)
 * `docs/.gitignore` [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)
-* `docs/Makefile` [#551](https://github.com/canonical/sphinx-docs-starter-pack/pull/551)
 * `docs/.sphinx/.wordlist.txt` [#520](https://github.com/canonical/sphinx-docs-starter-pack/pull/520)
 * `docs/conf.py` [#549](https://github.com/canonical/sphinx-docs-starter-pack/pull/549), [#558](https://github.com/canonical/sphinx-docs-starter-pack/pull/558), [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552), [#558](https://github.com/canonical/sphinx-docs-starter-pack/pull/558)
 * `docs/Makefile` [#551](https://github.com/canonical/sphinx-docs-starter-pack/pull/551), [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming
 
+* Update how copyright and license info is displayed in the footer
 * Fix the handling of non-zero exit codes from pymarkdownlnt.
 * Add a how-to guide about testing the Ulwazi theme.
 * Move the Python virtual environment from `docs/.sphinx/venv` to `docs/.venv`.
@@ -10,9 +11,11 @@
 
 ### Changed
 
+* `docs/conf.py` [#562](https://github.com/canonical/sphinx-docs-starter-pack/pull/562)
 * `.github/workflows/check-removed-urls.yml` [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)
 * `.github/workflows/sphinx-python-dependency-build-checks.yml` [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)
 * `docs/.gitignore` [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)
+* `docs/Makefile` [#551](https://github.com/canonical/sphinx-docs-starter-pack/pull/551)
 * `docs/.sphinx/.wordlist.txt` [#520](https://github.com/canonical/sphinx-docs-starter-pack/pull/520)
 * `docs/conf.py` [#549](https://github.com/canonical/sphinx-docs-starter-pack/pull/549), [#558](https://github.com/canonical/sphinx-docs-starter-pack/pull/558), [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552), [#558](https://github.com/canonical/sphinx-docs-starter-pack/pull/558)
 * `docs/Makefile` [#551](https://github.com/canonical/sphinx-docs-starter-pack/pull/551), [#552](https://github.com/canonical/sphinx-docs-starter-pack/pull/552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming
 
-* Update how copyright and license info is displayed in the footer
+* Separate default configuration for copyright and license statements.
 * Fix the handling of non-zero exit codes from pymarkdownlnt.
 * Add a how-to guide about testing the Ulwazi theme.
 * Move the Python virtual environment from `docs/.sphinx/venv` to `docs/.venv`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,22 +27,14 @@ import yaml
 project = "Documentation starter pack"
 author = "Canonical Ltd."
 
-# Copyright year; shown at the bottom of the page
+# The year in the copyright statement. Defaults to the current year, so
+# individual document versions show when they were built.
+# TODO: If the date must be a range, like in a software license, replace 
+# 2026 with the starting year of development and use:
 #
-# NOTE: For static works, it is common to provide the first publication year.
-#       Another option is to provide both the first year of publication
-#       and the current year, especially for docs that frequently change,
-#       e.g. 2022–2023 (note the en-dash).
-#
-#       A way to check a repo's creation date is to get a classic GitHub token
-#       with 'repo' permissions; see https://github.com/settings/tokens
-#       Next, use 'curl' and 'jq' to extract the date from the API's output:
-#
-#       curl -H 'Authorization: token <TOKEN>' \
-#         -H 'Accept: application/vnd.github.v3.raw' \
-#         https://api.github.com/repos/canonical/<REPO> | jq '.created_at'
+# copyright = f"2026-{datetime.date.today().year}"
 
-copyright = "2024"
+copyright = datetime.date.today().year
 
 # Sidebar documentation title; best kept reasonably short
 #
@@ -51,9 +43,6 @@ copyright = "2024"
 # TODO: To disable the title, set to an empty string.
 
 html_title = project + " documentation"
-
-
-
 
 
 # Documentation website URL

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,25 +27,7 @@ import yaml
 project = "Documentation starter pack"
 author = "Canonical Ltd."
 
-
-# Sidebar documentation title; best kept reasonably short
-#
-# TODO: To include a version number, add it here (hardcoded or automated).
-#
-# TODO: To disable the title, set to an empty string.
-
-html_title = project + " documentation"
-
-
-# Copyright string; shown at the bottom of the page
-#
-# Now, the starter pack uses CC-BY-SA as the license
-# and the current year as the copyright year.
-#
-# TODO: If your docs need another license, specify it instead of 'CC-BY-SA'.
-#
-# TODO: If your documentation is a part of the code repository of your project,
-#       it inherits the code license instead; specify it instead of 'CC-BY-SA'.
+# Copyright year; shown at the bottom of the page
 #
 # NOTE: For static works, it is common to provide the first publication year.
 #       Another option is to provide both the first year of publication
@@ -60,7 +42,18 @@ html_title = project + " documentation"
 #         -H 'Accept: application/vnd.github.v3.raw' \
 #         https://api.github.com/repos/canonical/<REPO> | jq '.created_at'
 
-copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
+copyright = "2024"
+
+# Sidebar documentation title; best kept reasonably short
+#
+# TODO: To include a version number, add it here (hardcoded or automated).
+#
+# TODO: To disable the title, set to an empty string.
+
+html_title = project + " documentation"
+
+
+
 
 
 # Documentation website URL
@@ -151,6 +144,26 @@ html_context = {
 
     # Required for feedback button    
     'github_issues': 'enabled',
+
+    # Inherit the author value
+    "author": author,
+
+    # The starter pack uses CC-BY-SA as the license
+    #
+    # TODO: If your docs need another license, specify it instead of 'CC-BY-SA'.
+    # For the name, we recommend using the standard shorthand identifier from
+    # https://spdx.org/licenses
+    #
+    # For the URL, link directly to the license statement, typically found on
+    # the product's home page or in its GitHub project.
+    #
+    # TODO: If your documentation is a part of the code repository of your project,
+    #       it inherits the code license instead; specify it instead of 'CC-BY-SA'.
+
+    "license": {
+        "name": "LGPL-3.0-only",
+        "url": "https://github.com/canonical/sphinx-docs-starter-pack/blob/main/LICENSE",
+    },
 }
 
 html_extra_path = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import yaml
 project = "Documentation starter pack"
 author = "Canonical Ltd."
 
-# The year in the copyright statement. Defaults to the current year, so
+# The year in the copyright statement defaults to the current year, so
 # individual document versions show when they were built.
 # TODO: If the date must be a range, like in a software license, replace 
 # 2026 with the starting year of development and use:
@@ -150,7 +150,7 @@ html_context = {
     #       it inherits the code license instead; specify it instead of 'CC-BY-SA'.
 
     "license": {
-        "name": "LGPL-3.0-only",
+        "name": "CC-BY-SA-3.0",
         "url": "https://github.com/canonical/sphinx-docs-starter-pack/blob/main/LICENSE",
     },
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ author = "Canonical Ltd."
 #
 # copyright = f"2026-{datetime.date.today().year}"
 
-copyright = datetime.date.today().year
+copyright = f"{datetime.date.today().year}"
 
 # Sidebar documentation title; best kept reasonably short
 #

--- a/docs/how-to/diagrams-as-code-mermaid.md
+++ b/docs/how-to/diagrams-as-code-mermaid.md
@@ -99,7 +99,7 @@ Here are some Canonical projects that use Mermaid for diagramming in their docum
 
 - [Checkbox](https://canonical-checkbox.readthedocs-hosted.com/stable/explanation/remote/)
 - [cloud-init](https://docs.cloud-init.io/en/latest/explanation/boot.html)
-- [Charmed MySQL K8s](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/explanation/flowcharts/#)
+- [Charmed MySQL K8s](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/8.0/explanation/flowcharts/)
 - [Ubuntu Pro](https://documentation.ubuntu.com/pro/support-overview/)
 
 ## Related topics

--- a/docs/how-to/diagrams-as-code-mermaid.md
+++ b/docs/how-to/diagrams-as-code-mermaid.md
@@ -99,6 +99,7 @@ Here are some Canonical projects that use Mermaid for diagramming in their docum
 
 - [Checkbox](https://canonical-checkbox.readthedocs-hosted.com/stable/explanation/remote/)
 - [cloud-init](https://docs.cloud-init.io/en/latest/explanation/boot.html)
+- [Charmed MySQL K8s](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/8.0/explanation/flowcharts/)
 - [Ubuntu Pro](https://documentation.ubuntu.com/pro/support-overview/)
 
 ## Related topics

--- a/docs/how-to/diagrams-as-code-mermaid.md
+++ b/docs/how-to/diagrams-as-code-mermaid.md
@@ -99,7 +99,6 @@ Here are some Canonical projects that use Mermaid for diagramming in their docum
 
 - [Checkbox](https://canonical-checkbox.readthedocs-hosted.com/stable/explanation/remote/)
 - [cloud-init](https://docs.cloud-init.io/en/latest/explanation/boot.html)
-- [Charmed MySQL K8s](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/8.0/explanation/flowcharts/)
 - [Ubuntu Pro](https://documentation.ubuntu.com/pro/support-overview/)
 
 ## Related topics

--- a/docs/how-to/diagrams-as-code-mermaid.md
+++ b/docs/how-to/diagrams-as-code-mermaid.md
@@ -99,7 +99,7 @@ Here are some Canonical projects that use Mermaid for diagramming in their docum
 
 - [Checkbox](https://canonical-checkbox.readthedocs-hosted.com/stable/explanation/remote/)
 - [cloud-init](https://docs.cloud-init.io/en/latest/explanation/boot.html)
-- [Charmed MySQL K8s](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/8.0/explanation/flowcharts/)
+- [Charmed MySQL K8s](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/explanation/flowcharts/#)
 - [Ubuntu Pro](https://documentation.ubuntu.com/pro/support-overview/)
 
 ## Related topics


### PR DESCRIPTION
## Description 
Canonical-sphinx has updated its way of displaying the copyright and license info at the bottom of the page. We need to update our conf.py to set new parameters to allow the correct display of the copyright notice and link to the license.

## Solution 

- Add author to html_context
- Convert copy right to year 
- Update comments instructions 
- Add license.name and license.url to html_context

## Preview 

<img width="381" height="102" alt="image" src="https://github.com/user-attachments/assets/5ffea77a-9be2-4a52-80b1-d407bc05eafa" />


## Issue 
Addresses #443 

- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
