### PR TITLE
Added intros, meta descriptions, relatedlinks

### DIFF
--- a/docs/how-to/build-and-preview.rst
+++ b/docs/how-to/build-and-preview.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: How to set up your environment and use make commands to build and preview documentation locally.
+
 .. _build-and-preview:
 
 Build and preview

--- a/docs/how-to/build-and-preview.rst
+++ b/docs/how-to/build-and-preview.rst
@@ -6,7 +6,7 @@
 Build and preview
 =================
 
-The starter pack provides a :file:`Makefile` that defines :command:`make` commands to build and view the documentation.
+The Starter Pack provides a :file:`Makefile` that defines :command:`make` commands to build and view the documentation.
 
 This guide describes how to set up your environment and use these commands to build and preview the documentation locally.
 
@@ -18,7 +18,7 @@ For more advanced information, including how to embed your docs build with your 
 Install prerequisite software
 -----------------------------
 
-The documentation framework that the starter pack uses bundles most prerequisites in a Python virtual environment, so you don't need to worry about installing them.
+The documentation framework that the Starter Pack uses bundles most prerequisites in a Python virtual environment, so you don't need to worry about installing them.
 There are only a few packages that you need to install on your host system.
 
 Before you start, make sure that you have ``make``, ``python3``, ``python3-venv``, and ``python3-pip`` on your system::
@@ -42,7 +42,7 @@ If you want to remove the installed Python packages (for example, to enforce a r
   make clean
 
 .. note::
-   - By default, the starter pack uses the latest compatible version of all tools and does not pin its requirements.
+   - By default, the Starter Pack uses the latest compatible version of all tools and does not pin its requirements.
      This might change temporarily if there is an incompatibility with a new tool version.
      There is therefore no need to use a tool like Renovate to automatically update the requirements.
 

--- a/docs/how-to/configure-your-project.rst
+++ b/docs/how-to/configure-your-project.rst
@@ -1,7 +1,12 @@
+.. meta::
+   :description: How to configure project-specific parameters.
+
 .. _configure-your-project:
 
 Configure your project
 ======================
+
+While the starter pack provides default configuration values for most settings, you'll need to set project-specific parameters like the project name to ensure the documentation reflects your project accurately.
 
 .. important::
 

--- a/docs/how-to/configure-your-project.rst
+++ b/docs/how-to/configure-your-project.rst
@@ -6,20 +6,20 @@
 Configure your project
 ======================
 
-While the starter pack provides default configuration values for most settings, you'll need to set project-specific parameters like the project name to ensure the documentation reflects your project accurately.
+While the Starter Pack provides default configuration values for most settings, you'll need to set project-specific parameters like the project name to ensure the documentation reflects your project accurately.
 
 .. important::
 
-   After setting up your repository with the starter pack, you should track the changes made to the starter pack.
+   After setting up your repository with the Starter Pack, you should track the changes made to the Starter Pack.
 
    Changes to the look and feel, as well as common functionality, will be automatically available through updates to the `Canonical Sphinx`_ extension.
 
-   Changes to files that are part of the starter pack, for example, :ref:`automatic-checks`, might require you to manually update your repository with the required files.
-   See the starter pack's `change log`_ for the most relevant (and of course all breaking) changes.
+   Changes to files that are part of the Starter Pack, for example, :ref:`automatic-checks`, might require you to manually update your repository with the required files.
+   See the Starter Pack's `change log`_ for the most relevant (and of course all breaking) changes.
 
-Configuration for a starter pack based documentation is set in the :file:`docs/conf.py` Sphinx configuration file.
+Configuration for a Starter Pack based documentation is set in the :file:`docs/conf.py` Sphinx configuration file.
 
-The starter pack's default configuration is prepared in a way that makes sense for most projects.
+The Starter Pack's default configuration is prepared in a way that makes sense for most projects.
 However, you must set some critical parameters that are unique for your project, like the project's name.
 
 In addition, you can find some optional parameters or add your own configuration parameters to the file.
@@ -51,12 +51,12 @@ You can leave the defaults for the website name and the preview image or specify
 Optional customisation
 ----------------------
 
-The starter pack contains several features that you can configure, or turn off if they aren't suitable for your documentation.
+The Starter Pack contains several features that you can configure, or turn off if they aren't suitable for your documentation.
 
 Modify the template
 ~~~~~~~~~~~~~~~~~~~
 
-The default starter pack templates provide an initial configuration for your documentation set, including:
+The default Starter Pack templates provide an initial configuration for your documentation set, including:
 
 - Header template - The top section of the page that contains your product's tag image and name, a link to your product's page (if available), and a drop-down menu for "More resources".
 - Footer template - The bottom section of the page that contains sequential navigation controls, copyright information, licensing details, and other relevant links.
@@ -69,7 +69,7 @@ See the :ref:`custom-html-templates` guide for details on how to do so.
 Deactivate the feedback button
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the starter pack includes a feedback button at the top of each page.
+By default, the Starter Pack includes a feedback button at the top of each page.
 This button redirects users to your GitHub issues page, and populates an issue for them with details of the page they were on when they clicked the button.
 
 If your project does not use GitHub issues, set the ``github_issues`` variable in the :file:`docs/conf.py` file to an empty value to disable both the feedback button and the issue link in the footer.
@@ -79,7 +79,7 @@ If you want to deactivate the feedback button, but keep the link in the footer, 
 Configure the contributor display
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the starter pack will display a list of contributors at the bottom of each page.
+By default, the Starter Pack will display a list of contributors at the bottom of each page.
 This requires the GitHub URL and folder to be configured.
 
 If you want to turn this contributor listing off, you can do so by setting the ``display_contributors`` variable in the :file:`docs/conf.py` file to ``False``.
@@ -109,10 +109,10 @@ Destination paths can also be external URLs.
 Configure included extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The starter pack includes a set of extensions that are useful for all documentation sets.
+The Starter Pack includes a set of extensions that are useful for all documentation sets.
 Some extensions are :ref:`enabled by default <reference-default-sphinx-extensions>` within the Starter Pack, but you can customize the selection in the  :file:`docs/conf.py` file.
 
-The ``canonical_sphinx`` extension is required for the starter pack and provides the Furo-based theme and custom templates.
+The ``canonical_sphinx`` extension is required for the Starter Pack and provides the Furo-based theme and custom templates.
 
 To add new extensions needed for your documentation set, add them to the ``extensions`` parameter in :file:`docs/conf.py`.
 

--- a/docs/how-to/contributing-myst.md
+++ b/docs/how-to/contributing-myst.md
@@ -201,9 +201,9 @@ TODO: test command 2
 
 ## Documentation
 
-ACME's documentation is stored in the `DOCDIR` directory of the repository. It is based on the [Canonical starter pack](https://canonical-starter-pack.readthedocs-hosted.com/stable/) and hosted on [Read the Docs](https://about.readthedocs.com/).
+ACME's documentation is stored in the `DOCDIR` directory of the repository. It is based on the [Canonical Starter Pack](https://canonical-starter-pack.readthedocs-hosted.com/stable/) and hosted on [Read the Docs](https://about.readthedocs.com/).
 
-For general guidance, refer to the [starter pack guide](https://canonical-starter-pack.readthedocs-hosted.com/stable/).
+For general guidance, refer to the [Starter Pack guide](https://canonical-starter-pack.readthedocs-hosted.com/stable/).
 
 For syntax help and guidelines, refer to the syntax guides contained in the [rST](project:#rst-syntax) and [MyST](project:#myst-syntax) syntax guides.
 

--- a/docs/how-to/contributing.rst
+++ b/docs/how-to/contributing.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: How to contribute to the documentation project with code, writing, or testing.
+
 :orphan:
 
 .. TODO: Replace all mentions of ACME with your project name

--- a/docs/how-to/contributing.rst
+++ b/docs/how-to/contributing.rst
@@ -297,7 +297,7 @@ Documentation
 -------------
 
 ACME's documentation is stored in the ``DOCDIR`` directory of the repository.
-It is based on the `Canonical starter pack
+It is based on the `Canonical Starter Pack
 <https://canonical-starter-pack.readthedocs-hosted.com/stable/>`_
 and hosted on `Read the Docs <https://about.readthedocs.com/>`_.
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -8,7 +8,7 @@ How-to guides
 =============
 
 These guides will walk you through the processes involving setting up,
-maintaining, and contributing to the starter pack.
+maintaining, and contributing to the Starter Pack.
 
 Basic setup and maintenance
 ---------------------------
@@ -32,7 +32,7 @@ As your documentation grows, you may need more advanced features to support rich
 can include customising the build system, adding diagrams as code, rendering API references, interactive 
 tables, and custom HTML.
 
-While some of these features are available by default in the starter pack, others may require additional 
+While some of these features are available by default in the Starter Pack, others may require additional 
 extensions.
 
 The following guides will help you get started:

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -13,7 +13,7 @@ maintaining, and contributing to the starter pack.
 Basic setup and maintenance
 ---------------------------
 
-Set up, configure, upgrade, and customize your project to keep it organized and aligned with 
+Set up, configure, update, and customize your project to keep it organized and aligned with 
 your documentation needs.
 
 .. toctree::

--- a/docs/how-to/optional-customisation/add-documentation-testing.rst
+++ b/docs/how-to/optional-customisation/add-documentation-testing.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: How to use Spread to automatically test commands in documentation and keep them in sync with your product.
+
 .. _how-to-add-documentation-testing:
 
 Use Spread to test commands in documentation

--- a/docs/how-to/optional-customisation/add-documentation-testing.rst
+++ b/docs/how-to/optional-customisation/add-documentation-testing.rst
@@ -193,7 +193,7 @@ For example, consider the following ``task.yaml`` file:
 .. code-block:: yaml
     :caption: task.yaml
 
-    summary: Clone and build the starter pack
+    summary: Clone and build the Starter Pack
 
     kill-timeout: 5m
 
@@ -217,7 +217,7 @@ Include the commands from ``task.yaml`` in your documentation with:
       .. code-block:: rst
         :caption: Example ``literalinclude`` blocks
 
-        Clone the starter pack:
+        Clone the Starter Pack:
 
         .. literalinclude:: relative-path-to/task.yaml
             :language: bash
@@ -239,7 +239,7 @@ Include the commands from ``task.yaml`` in your documentation with:
       .. code-block:: md
         :caption: Example ``literalinclude`` blocks
 
-        Clone the starter pack:
+        Clone the Starter Pack:
 
         ```{literalinclude} relative-path-to/task.yaml
         :language: bash

--- a/docs/how-to/optional-customisation/bridge-project-and-docs-builds.rst
+++ b/docs/how-to/optional-customisation/bridge-project-and-docs-builds.rst
@@ -12,7 +12,7 @@ Bridge project and documentation builds
 .. If more parent projects and build systems are tested, make the introduction general 
    and add tabs to each of the steps
 
-The starter pack can be used as a standalone docs repository, or embedded inside a
+The Starter Pack can be used as a standalone docs repository, or embedded inside a
 parent project. This guide demonstrates how to bridge the docs build with a Python
 project's main build. Once bridged, project contributors can install, build, and check
 the docs from the root of the project with the main build system.
@@ -34,7 +34,7 @@ capable of adding targets that call other systems. When shimmed, the docs target
 
 The bridge also **merges the virtual environments**, removing the need for a separate
 docs environment. This change is optional but recommended. To combine environments, your
-project must provide **Python 3.11** or higher to the starter pack. Any Python
+project must provide **Python 3.11** or higher to the Starter Pack. Any Python
 dependency manager will do, and this guide illustrates with three:
 
 - pip 25.1 and higher
@@ -137,10 +137,10 @@ three dependency groups in ``pyproject.toml``:
 
 - ``dev`` for development builds
 - ``docs`` for extra docs packages that your project needs
-- ``docs-starter-pack`` for the core docs packages set by the starter pack
+- ``docs-starter-pack`` for the core docs packages set by the Starter Pack
 
 First, add these dependency groups, and make the docs dependencies include the
-starter pack packages:
+Starter Pack packages:
 
 .. code-block:: toml
     :caption: pyproject.toml
@@ -306,7 +306,7 @@ Here's what it looks like in the example project:
 Adjust the doc workflows
 ------------------------
 
-If your project uses the starter pack's docs workflows *and* Make, adjust the workflows
+If your project uses the Starter Pack's docs workflows *and* Make, adjust the workflows
 to use the bridged targets.
 
 For the main checks, override the target names and paths through the `workflow inputs

--- a/docs/how-to/optional-customisation/bridge-project-and-docs-builds.rst
+++ b/docs/how-to/optional-customisation/bridge-project-and-docs-builds.rst
@@ -271,7 +271,7 @@ Adjust the Read the Docs build
 ------------------------------
 
 With the Makefile in a different location than usual, and its being a separate process,
-it's simplest to override the Read The Docs build in ``.readthedocs.yaml`` to call the
+it's simplest to override the Read the Docs build in ``.readthedocs.yaml`` to call the
 same build targets that developers use locally.
 
 If you use an uncommon system, you might need to install it during the workflow's

--- a/docs/how-to/optional-customisation/custom-html-templates.md
+++ b/docs/how-to/optional-customisation/custom-html-templates.md
@@ -8,13 +8,13 @@ myst:
 
 # Use custom HTML templates
 
-If the default template in the starter pack doesn't fully meet your needs -- whether you want a unique layout, a custom header or footer, or a specialized sidebar for certain pages -- you can create and use a custom template for your project.
+If the default template in the Starter Pack doesn't fully meet your needs -- whether you want a unique layout, a custom header or footer, or a specialized sidebar for certain pages -- you can create and use a custom template for your project.
 
-This guide shows you how to extend or override the default templates in the starter pack to tailor the look and structure of your documentation.
+This guide shows you how to extend or override the default templates in the Starter Pack to tailor the look and structure of your documentation.
 
 ```{note}
 Base template customizations can be made to your documentation.
-However, they are not officially supported by the team maintaining the starter pack.
+However, they are not officially supported by the team maintaining the Starter Pack.
 Use them at your own discretion.
 ```
 

--- a/docs/how-to/optional-customisation/custom-html-templates.md
+++ b/docs/how-to/optional-customisation/custom-html-templates.md
@@ -1,10 +1,16 @@
+---
+myst:
+  html_meta:
+    description: How to extend or override default HTML templates to customize documentation structure and layout.
+---
+
 (custom-html-templates)=
 
 # Use custom HTML templates
 
-If the default template in the Starter Pack doesn't fully meet your needs -- whether you want a unique layout, a custom header or footer, or a specialized sidebar for certain pages -- you can create and use a custom template for your Sphinx project.
+If the default template in the starter pack doesn't fully meet your needs -- whether you want a unique layout, a custom header or footer, or a specialized sidebar for certain pages -- you can create and use a custom template for your project.
 
-This guide shows you how to extend or override the default templates in the Starter Pack to tailor the look and structure of your documentation.
+This guide shows you how to extend or override the default templates in the starter pack to tailor the look and structure of your documentation.
 
 ```{note}
 Base template customizations can be made to your documentation.
@@ -16,7 +22,7 @@ Use them at your own discretion.
 
 First, create the {file}`docs/_templates` directory; all your custom templates will need to be stored in this folder.
 
-Then uncomment this line in {file}`docs/conf.py` so your Sphinx project will use local templates (where available):
+Then uncomment this line in {file}`docs/conf.py` so your project will use local templates (where available):
 
 ```{code-block} py
 :caption: conf\.py

--- a/docs/how-to/optional-customisation/customise-pdf.rst
+++ b/docs/how-to/optional-customisation/customise-pdf.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: How to customize PDF output using LaTeX configuration.
+
 .. _pdf-customise:
 
 Customise PDF output
@@ -13,7 +16,7 @@ Customising PDF output involves two levels of configuration:
 * **Sphinx configuration**: built-in options for configuring LaTeX build process in :file:`conf.py`, for example: the engine used to generate the PDF, output file name, and input file paths.
 * **LaTeX configuration**: the LaTeX packages, styling, and configuration for the PDF output, set through the :literalref:`latex_elements <https://www.sphinx-doc.org/en/master/latex.html#the-latex-elements-configuration-setting>` dictionary in the project :file:`conf.py`. In the starter-pack, a default set of LaTeX elements is provided by the ``canonical-sphinx`` extension. Changing the LaTeX configuration requires overriding the default values loaded from the extension.
 
-This guide covers common practices and tips for customising PDF output from your documentation project using the starter pack and the ``canonical-sphinx`` extension.
+This guide covers common practices and tips for customising PDF output from your project using the starter pack and the ``canonical-sphinx`` extension.
 
 For basic instructions about building the PDF, see :ref:`build-and-preview`.
 
@@ -115,7 +118,7 @@ The LaTeX template is a text file in the ``canonical-sphinx`` extension that pro
 
 Any additions or changes to the default settings of LaTeX elements in the PDF document requires overriding the default template.
 
-1. Download the default template file `latex_elements_template.txt <https://github.com/canonical/canonical-sphinx/blob/main/canonical_sphinx/theme/PDF/latex_elements_template.txt>`_ from the ``canonical/canonical-sphinx`` GitHub repository, and save it to your documentation project directory. For example, at :file:`.sphinx/latex_elements_custom.txt`.
+1. Download the default template file `latex_elements_template.txt <https://github.com/canonical/canonical-sphinx/blob/main/canonical_sphinx/theme/PDF/latex_elements_template.txt>`_ from the ``canonical/canonical-sphinx`` GitHub repository, and save it to your project directory. For example, at :file:`.sphinx/latex_elements_custom.txt`.
 
 2. In the Python dictionary, add or modify the LaTeX elements you want to change. Details of changing the dictionary are covered in the sub-sections below.
 

--- a/docs/how-to/optional-customisation/customise-pdf.rst
+++ b/docs/how-to/optional-customisation/customise-pdf.rst
@@ -1,5 +1,5 @@
 .. meta::
-   :description: How to customize PDF output using LaTeX configuration.
+   :description: How to customize PDF output with LaTeX.
 
 .. _pdf-customise:
 

--- a/docs/how-to/optional-customisation/customise-pdf.rst
+++ b/docs/how-to/optional-customisation/customise-pdf.rst
@@ -9,14 +9,14 @@ Customise PDF output
 Overview
 --------
 
-The starter pack supports PDF output via LaTeX using the ``make pdf`` command. This build process relies on system packages, Sphinx configurations, and a LaTeX template from the ``canonical-sphinx`` extension.
+The Starter Pack supports PDF output via LaTeX using the ``make pdf`` command. This build process relies on system packages, Sphinx configurations, and a LaTeX template from the ``canonical-sphinx`` extension.
 
 Customising PDF output involves two levels of configuration:
 
 * **Sphinx configuration**: built-in options for configuring LaTeX build process in :file:`conf.py`, for example: the engine used to generate the PDF, output file name, and input file paths.
 * **LaTeX configuration**: the LaTeX packages, styling, and configuration for the PDF output, set through the :literalref:`latex_elements <https://www.sphinx-doc.org/en/master/latex.html#the-latex-elements-configuration-setting>` dictionary in the project :file:`conf.py`. In the starter-pack, a default set of LaTeX elements is provided by the ``canonical-sphinx`` extension. Changing the LaTeX configuration requires overriding the default values loaded from the extension.
 
-This guide covers common practices and tips for customising PDF output from your project using the starter pack and the ``canonical-sphinx`` extension.
+This guide covers common practices and tips for customising PDF output from your project using the Starter Pack and the ``canonical-sphinx`` extension.
 
 For basic instructions about building the PDF, see :ref:`build-and-preview`.
 

--- a/docs/how-to/optional-customisation/enable-google-analytics.rst
+++ b/docs/how-to/optional-customisation/enable-google-analytics.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: How to enable Google Analytics in your project.
+
 .. _how-to-enable-google-analytics:
 
 Enable Google Analytics
@@ -20,7 +23,7 @@ page interaction.
 The footer template provides a link for users to change their data collection
 preferences.
 
-The process for sourcing these files depends on your Starter Pack version. Check which
+The process for sourcing these files depends on your starter pack version. Check which
 version is listed in your project's ``docs/.sphinx/version`` file.
 
 

--- a/docs/how-to/optional-customisation/enable-google-analytics.rst
+++ b/docs/how-to/optional-customisation/enable-google-analytics.rst
@@ -23,7 +23,7 @@ page interaction.
 The footer template provides a link for users to change their data collection
 preferences.
 
-The process for sourcing these files depends on your starter pack version. Check which
+The process for sourcing these files depends on your Starter Pack version. Check which
 version is listed in your project's ``docs/.sphinx/version`` file.
 
 

--- a/docs/how-to/optional-customisation/interactive-tables.rst
+++ b/docs/how-to/optional-customisation/interactive-tables.rst
@@ -1,9 +1,14 @@
+.. meta::
+   :description: How to add interactive data tables to your project with sorting and filtering capabilities.
+
 .. _interactive-tables:
 
 Add interactive data tables
 ===========================
 
-The `Sphinx DataTables`_ extension enables interactive tables. Users can sort columns and filter rows. For examples, see the extension's documentation.
+Data-heavy documentation often benefits from tables that users can explore interactively.
+The `Sphinx DataTables`_ extension enables interactive tables where users can sort columns and filter rows, making large datasets more navigable and useful.
+For examples, see the extension's documentation.
 
 The extension isn't available by default in the starter pack. To read more about table functionality that is available out of the box, see :ref:`Tables (MyST) <myst_style_guide_tables>` and :ref:`Tables (reST) <style-guide-tables>`.
 

--- a/docs/how-to/optional-customisation/interactive-tables.rst
+++ b/docs/how-to/optional-customisation/interactive-tables.rst
@@ -7,7 +7,7 @@ Add interactive data tables
 ===========================
 
 Data-heavy documentation often benefits from tables that users can explore interactively.
-The `Sphinx DataTables`_ extension enables interactive tables where users can sort columns and filter rows, making large datasets more navigable and useful.
+The `Sphinx DataTables`_ extension provides interactive tables where users can sort columns and filter rows, making large datasets more navigable and useful.
 For examples, see the extension's documentation.
 
 The extension isn't available by default in the starter pack. To read more about table functionality that is available out of the box, see :ref:`Tables (MyST) <myst_style_guide_tables>` and :ref:`Tables (reST) <style-guide-tables>`.

--- a/docs/how-to/optional-customisation/interactive-tables.rst
+++ b/docs/how-to/optional-customisation/interactive-tables.rst
@@ -10,7 +10,7 @@ Data-heavy documentation often benefits from tables that users can explore inter
 The `Sphinx DataTables`_ extension provides interactive tables where users can sort columns and filter rows, making large datasets more navigable and useful.
 For examples, see the extension's documentation.
 
-The extension isn't available by default in the starter pack. To read more about table functionality that is available out of the box, see :ref:`Tables (MyST) <myst_style_guide_tables>` and :ref:`Tables (reST) <style-guide-tables>`.
+The extension isn't available by default in the Starter Pack. To read more about table functionality that is available out of the box, see :ref:`Tables (MyST) <myst_style_guide_tables>` and :ref:`Tables (reST) <style-guide-tables>`.
 
 Include the ``sphinx-datatables`` extension
 -------------------------------------------

--- a/docs/how-to/optional-customisation/mermaid-diagrams.md
+++ b/docs/how-to/optional-customisation/mermaid-diagrams.md
@@ -16,7 +16,7 @@ Mermaid is a popular choice that allows diagrams to be created, maintained, and 
 This guide explains how to set up the {doc}`sphinxcontrib-mermaid <sphinxcontrib-mermaid:index>` extension and use Mermaid diagrams in your documentation, with examples included.
 
 ```{note}
-While there are many other tools and/or approaches for creating diagrams in visualizations in your documentation (e.g. [C4 model], [Dia], [PlantUML], [Structurizr], etc), we only provide support for `sphinxcontrib-mermaid` in the starter pack. 
+While there are many other tools and/or approaches for creating diagrams in visualizations in your documentation (e.g. [C4 model], [Dia], [PlantUML], [Structurizr], etc), we only provide support for `sphinxcontrib-mermaid` in the Starter Pack. 
 ```
 
 ## Installation and setup

--- a/docs/how-to/optional-customisation/mermaid-diagrams.md
+++ b/docs/how-to/optional-customisation/mermaid-diagrams.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    description: How to create and embed diagrams in your documentation using Mermaid.
+relatedlinks: https://mermaid.js.org/intro/, https://mermaid.live/
+---
+
 (howto-diagram-as-code-mermaid)=
 
 # Create diagrams as code using Mermaid
@@ -102,11 +109,6 @@ Here are some Canonical projects that use Mermaid for diagramming in their docum
 - [Charmed MySQL K8s](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/8.0/explanation/flowcharts/)
 - [Ubuntu Pro](https://documentation.ubuntu.com/pro/support-overview/)
 
-## Related topics
-
-- See the [Official Mermaid documentation] for setup and configuration instructions, full syntax for the different types of Mermaid diagrams.
-- Try out the [Mermaid Live Editor] if you want a playground to work on your diagrams.
-
 % LINKS
 
 [Mermaid version]: https://unpkg.com/browse/mermaid/
@@ -120,3 +122,4 @@ Here are some Canonical projects that use Mermaid for diagramming in their docum
 [Dia]: http://dia-installer.de/
 [PlantUML]: https://plantuml.com/
 [Structurizr]: https://structurizr.com/
+

--- a/docs/how-to/optional-customisation/openapi-specifications.rst
+++ b/docs/how-to/optional-customisation/openapi-specifications.rst
@@ -1,13 +1,13 @@
+.. meta::
+   :description: How to add an OpenAPI integration to your project.
+
 .. _how-to-openapi:
 
 Add OpenAPI integration
 =======================
 
-Use this guide to add a minimal OpenAPI integration for the starter pack.
-This implementation uses `Swagger UI <https://swagger.io/tools/swagger-ui/>`_;
-it includes a basic specification and an opt-in tag toggle --
-based on a build-time environment variable --
-to keep the documentation clean by default.
+OpenAPI specifications provide a standardized way to document REST APIs.
+This guide demonstrates how to add a minimal OpenAPI integration to your project using `Swagger UI <https://swagger.io/tools/swagger-ui/>`_, including a basic specification and an opt-in tag toggle based on a build-time environment variable to keep the documentation clean by default.
 
 Locate the specification
 ------------------------

--- a/docs/how-to/optional-customisation/python-docstrings.md
+++ b/docs/how-to/optional-customisation/python-docstrings.md
@@ -57,7 +57,7 @@ There are a few issues and limitations that should be taken into consideration.
 
 ### Language
 
-The extension's usage is limited to Python code. There are extensions for some other languages but they have not been tested with the starter pack, such as [sphinxcontrib-rust](https://sphinxcontrib-rust.readthedocs.io/en/stable/) for Rust.
+The extension's usage is limited to Python code. There are extensions for some other languages but they have not been tested with the Starter Pack, such as [sphinxcontrib-rust](https://sphinxcontrib-rust.readthedocs.io/en/stable/) for Rust.
 
 ### Docstring format
 

--- a/docs/how-to/optional-customisation/python-docstrings.md
+++ b/docs/how-to/optional-customisation/python-docstrings.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: How to import Python docstrings automatically into your documentation using Sphinx autodoc extension.
+    description: How to import Python docstrings automatically into your documentation using the Sphinx autodoc extension.
 ---
 
 (sphinx-autodoc)=

--- a/docs/how-to/optional-customisation/python-docstrings.md
+++ b/docs/how-to/optional-customisation/python-docstrings.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: How to import Python docstrings automatically into your documentation using Sphinx autodoc extension.
+---
+
 (sphinx-autodoc)=
 
 # Import docstrings with Sphinx `autodoc`
@@ -51,7 +57,7 @@ There are a few issues and limitations that should be taken into consideration.
 
 ### Language
 
-The extension's usage is limited to Python code. There are extensions for some other languages but they have not been tested with the Starter Pack, such as [sphinxcontrib-rust](https://sphinxcontrib-rust.readthedocs.io/en/stable/) for Rust.
+The extension's usage is limited to Python code. There are extensions for some other languages but they have not been tested with the starter pack, such as [sphinxcontrib-rust](https://sphinxcontrib-rust.readthedocs.io/en/stable/) for Rust.
 
 ### Docstring format
 

--- a/docs/how-to/publish-on-rtd.rst
+++ b/docs/how-to/publish-on-rtd.rst
@@ -7,11 +7,11 @@ Publish on Read the Docs
 ========================
 
 Publishing your documentation on Read the Docs makes it available to a wider audience with automatic builds triggered by repository updates.
-This guide walks you through the process of setting up your starter pack-based project on the Read the Docs platform.
+This guide walks you through the process of setting up your Starter Pack-based project on the Read the Docs platform.
 
 For Canonical-specific information on how to set up your documentation on Read the Docs, see the `Read the Docs at Canonical <https://library.canonical.com/documentation/read-the-docs-at-canonical>`_ and `How to publish documentation on Read the Docs <https://library.canonical.com/documentation/publish-on-read-the-docs>`_ guides.
 
-In general, after enabling the starter pack for your documentation, follow these steps to build and publish your documentation on Read the Docs:
+In general, after enabling the Starter Pack for your documentation, follow these steps to build and publish your documentation on Read the Docs:
 
 1. Make sure your documentation :ref:`builds without errors or warnings <build-clean>`.
 #. Log into Read the Docs.

--- a/docs/how-to/publish-on-rtd.rst
+++ b/docs/how-to/publish-on-rtd.rst
@@ -1,7 +1,13 @@
+.. meta::
+   :description: How to publish your documentation on Read the Docs.
+
 .. _publish-on-rtd:
 
 Publish on Read the Docs
 ========================
+
+Publishing your documentation on Read the Docs makes it available to a wider audience with automatic builds triggered by repository updates.
+This guide walks you through the process of setting up your starter pack-based project on the Read the Docs platform.
 
 For Canonical-specific information on how to set up your documentation on Read the Docs, see the `Read the Docs at Canonical <https://library.canonical.com/documentation/read-the-docs-at-canonical>`_ and `How to publish documentation on Read the Docs <https://library.canonical.com/documentation/publish-on-read-the-docs>`_ guides.
 

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -6,7 +6,7 @@
 Troubleshooting
 ===================
 
-This page provides guidance to resolve issues with the Starter Pack and Read The Docs
+This page provides guidance to resolve issues with the Starter Pack and Read the Docs
 that are difficult to identify or that we don't expect to be solved.
 
 

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -1,12 +1,12 @@
 .. meta::
-   :description: How to troubleshoot common issues with the Sphinx starter pack and Read the Docs.
+   :description: How to troubleshoot common issues with the Sphinx Starter Pack and Read the Docs.
 
 .. _troubleshooting:
 
 Troubleshooting
 ===================
 
-This page provides guidance to resolve issues with the starter pack and Read The Docs
+This page provides guidance to resolve issues with the Starter Pack and Read The Docs
 that are difficult to identify or that we don't expect to be solved.
 
 

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -1,9 +1,12 @@
+.. meta::
+   :description: How to troubleshoot common issues with the Sphinx starter pack and Read the Docs.
+
 .. _troubleshooting:
 
 Troubleshooting
 ===================
 
-This page provides guidance to resolve issues with the Starter Pack and ReadTheDocs
+This page provides guidance to resolve issues with the starter pack and Read The Docs
 that are difficult to identify or that we don't expect to be solved.
 
 

--- a/docs/how-to/update-starter-packs/index.rst
+++ b/docs/how-to/update-starter-packs/index.rst
@@ -1,47 +1,47 @@
 .. meta::
-   :description: Learn how to update your Sphinx starter pack with the latest features and improvements.
+   :description: Learn how to update your Sphinx Starter Pack with the latest features and improvements.
 
 .. _update-starter-packs:
 
 ========================
-Update your starter pack
+Update your Starter Pack
 ========================
 
-The starter pack is updated frequently. After you copy its code and it becomes the documentation system in your project, you must manually maintain it. 
+The Starter Pack is updated frequently. After you copy its code and it becomes the documentation system in your project, you must manually maintain it. 
 
-There are special pathways to bring in the latest features and improvements from the starter pack repository.
+There are special pathways to bring in the latest features and improvements from the Starter Pack repository.
 
 Determine your current version
 ------------------------------
 
-There are two versions of the starter pack that entail different update processes:
+There are two versions of the Starter Pack that entail different update processes:
 
-- the **new**, or **extension-based** starter pack
-- the **legacy**, or **pre-extension** starter pack
+- the **new**, or **extension-based** Starter Pack
+- the **legacy**, or **pre-extension** Starter Pack
 
-New starter pack
+New Starter Pack
 ^^^^^^^^^^^^^^^^^
 
-If your :file:`conf.py` includes ``canonical-sphinx`` under the ``extensions`` list, you are using the new starter pack. 
+If your :file:`conf.py` includes ``canonical-sphinx`` under the ``extensions`` list, you are using the new Starter Pack. 
 
-To update a new starter pack project to the latest version, see:
+To update a new Starter Pack project to the latest version, see:
 
 - :ref:`update-new-starter-pack`
 
 .. note::
-   New starter pack releases use a semantic versioning scheme for minor and patch versions, which can be found in your project's :file:`.sphinx/version` file. 
+   New Starter Pack releases use a semantic versioning scheme for minor and patch versions, which can be found in your project's :file:`.sphinx/version` file. 
 
-Legacy starter pack
+Legacy Starter Pack
 ^^^^^^^^^^^^^^^^^^^^
 
-If your :file:`conf.py` does _not_ include ``canonical-sphinx`` you are using the legacy starter pack. 
+If your :file:`conf.py` does _not_ include ``canonical-sphinx`` you are using the legacy Starter Pack. 
 
-To update a legacy starter pack project to the latest version of the new starter pack:
+To update a legacy Starter Pack project to the latest version of the new Starter Pack:
 
 - :ref:`update-legacy-starter-pack`
 
 .. toctree::
    :hidden:
 
-    New starter pack <new-starter-pack>
-    Legacy starter pack <legacy-starter-pack>
+    New Starter Pack <new-starter-pack>
+    Legacy Starter Pack <legacy-starter-pack>

--- a/docs/how-to/update-starter-packs/legacy-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/legacy-starter-pack.rst
@@ -1,19 +1,19 @@
 .. meta::
-   :description: Learn how to update Sphinx starter pack projects that don't yet use the canonical-sphinx extension.
+   :description: Learn how to update Sphinx Starter Pack projects that don't yet use the canonical-sphinx extension.
 
 .. _update-legacy-starter-pack:
 
-Update the legacy starter pack 
+Update the legacy Starter Pack 
 ==============================
 
 This guide outlines the steps required to migrate a documentation project from the legacy Sphinx Documentation Starter Pack (*pre-extension* version) to the latest version that adopts the ``canonical-sphinx`` Sphinx extension.
 
-The extension-based documentation starter pack provides a set of features and configurations that are common across Canonical documentation projects. Key components, such as configuration and styling, are loaded as an add-on to your project. It can significantly reduce maintenance concerns when managing your documentation.
+The extension-based documentation Starter Pack provides a set of features and configurations that are common across Canonical documentation projects. Key components, such as configuration and styling, are loaded as an add-on to your project. It can significantly reduce maintenance concerns when managing your documentation.
 
 .. note::
    If ``canonical-sphinx`` is included under ``extensions`` in your `conf.py`, 
    you are already using an extension-based starter-pack. Follow the guide on 
-   :ref:`updating the new starter pack <update-new-starter-pack>`.
+   :ref:`updating the new Starter Pack <update-new-starter-pack>`.
 
 Update to the last pre-extension version
 ----------------------------------------
@@ -45,7 +45,7 @@ Set up a new project
 
       If you proceed in the same directory, the following steps will overwrite some of the configuration files in the original project.
 
-2. Follow the steps in the :ref:`initial-setup` guide to initialise an empty project with the extension-based starter pack, at the original file path.
+2. Follow the steps in the :ref:`initial-setup` guide to initialise an empty project with the extension-based Starter Pack, at the original file path.
 
 3. Ensure the following files are at the root of your repository:
 
@@ -62,7 +62,7 @@ Set up a new project
 Migrate source files
 --------------------
 
-The documentation starter pack has undergone breaking changes with the introduction of the ``canonical-sphinx`` extension. This section guides you through:
+The documentation Starter Pack has undergone breaking changes with the introduction of the ``canonical-sphinx`` extension. This section guides you through:
 
 - Configuration file changes
 - Extension dependencies
@@ -73,7 +73,7 @@ For a complete list of the structural changes, refer to the `directory-structure
 Sphinx configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
-A significant change in the new starter pack is the organisation of the configuration files, summarised in the following table:
+A significant change in the new Starter Pack is the organisation of the configuration files, summarised in the following table:
 
 .. list-table::
    :widths: 20 40 40
@@ -83,13 +83,13 @@ A significant change in the new starter pack is the organisation of the configur
      - Pre-extension 
      - Extension-based
    * - ``conf.py``
-     - Common configurations shared by all starter pack projects
+     - Common configurations shared by all Starter Pack projects
      - Project-specific configurations
    * - ``custom_conf.py``
      - Project-specific configuration
      - Merged into ``conf.py`` and removed
 
-In the new starter pack, many common configurations are provided by the extension and are loaded automatically when building the documentation. ``docs/conf.py`` is the only configuration file, and it contains all project-specific configuration. Sensible defaults are set for general configuration by inclusion of the `canonical-sphinx` extension.
+In the new Starter Pack, many common configurations are provided by the extension and are loaded automatically when building the documentation. ``docs/conf.py`` is the only configuration file, and it contains all project-specific configuration. Sensible defaults are set for general configuration by inclusion of the `canonical-sphinx` extension.
 
 Ensure that all the previous changes in the original ``custom_conf.py`` file are copied to the new ``conf.py`` file.  
 
@@ -101,7 +101,7 @@ If your project requires additional extensions beyond the default list, add the 
 Documentation source files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Remove the starter pack's documentation files (``index.rst`` and any files in the ``docs/**/*`` sub-directory).
+1. Remove the Starter Pack's documentation files (``index.rst`` and any files in the ``docs/**/*`` sub-directory).
 
 2. Copy all documentation source files from your original project to the new project, keeping their original structure. These file may include but are not limited to:
 
@@ -124,7 +124,7 @@ For general information on customising the extension configuration, see :ref:`co
 Static resources
 ~~~~~~~~~~~~~~~~
 
-The extension provides a set of static resources, such as images, fonts, CSS files, and HTML templates, that are used to style the documentation for Canonical-branded design. These resources are bundled with the extension and are no longer provided as source files in the new starter pack.
+The extension provides a set of static resources, such as images, fonts, CSS files, and HTML templates, that are used to style the documentation for Canonical-branded design. These resources are bundled with the extension and are no longer provided as source files in the new Starter Pack.
 
 If you have customised any of these resources in the original project, you need to manually migrate these changes to the new project. 
 

--- a/docs/how-to/update-starter-packs/legacy-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/legacy-starter-pack.rst
@@ -8,7 +8,7 @@ Update the legacy starter pack
 
 This guide outlines the steps required to migrate a documentation project from the legacy Sphinx Documentation Starter Pack (*pre-extension* version) to the latest version that adopts the ``canonical-sphinx`` Sphinx extension.
 
-The extension-based documentation starter pack provides a set of features and configurations that are common across Canonical documentation projects. Key components, such as configuration and styling, are loaded as an add-on to your documentation project. It can significantly reduce maintenance concerns when managing your documentation.
+The extension-based documentation starter pack provides a set of features and configurations that are common across Canonical documentation projects. Key components, such as configuration and styling, are loaded as an add-on to your project. It can significantly reduce maintenance concerns when managing your documentation.
 
 .. note::
    If ``canonical-sphinx`` is included under ``extensions`` in your `conf.py`, 

--- a/docs/how-to/update-starter-packs/new-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/new-starter-pack.rst
@@ -1,37 +1,37 @@
 .. meta::
-   :description: Learn how to update Sphinx starter pack projects that use the canonical-sphinx extension.
+   :description: Learn how to update Sphinx Starter Pack projects that use the canonical-sphinx extension.
 
 .. _update-new-starter-pack:
 
-Update the new starter pack
+Update the new Starter Pack
 ===========================
 
-The documentation starter pack is regularly updated to add features and address 
+The documentation Starter Pack is regularly updated to add features and address 
 bugs. You can transfer these improvements to your project by following these steps:
 
-- Clone the latest version of the starter pack
-- Compare key files and directories in the starter pack to your project 
+- Clone the latest version of the Starter Pack
+- Compare key files and directories in the Starter Pack to your project 
 - Transfer or delete relevant changes 
 - Confirm that your project builds correctly with the new changes
 
 This guide assumes your project has minimal customizations, and the repository 
-structure closely mirrors the starter pack's. Depending on your customizations, 
+structure closely mirrors the Starter Pack's. Depending on your customizations, 
 you may need to take extra steps when updating. 
 
 .. note::
    If ``canonical-sphinx`` is not included under ``extensions`` in your ``conf.py``, 
    your project is not on an extension-based starter-pack. Follow the guide on 
-   :ref:`updating a legacy starter pack project <update-legacy-starter-pack>`.
+   :ref:`updating a legacy Starter Pack project <update-legacy-starter-pack>`.
 
-Clone the starter pack repository
+Clone the Starter Pack repository
 ---------------------------------
-If you don't have a clean, local copy of the starter pack, clone it:
+If you don't have a clean, local copy of the Starter Pack, clone it:
 
 .. code-block::
 
     git clone https://github.com/canonical/sphinx-docs-starter-pack.git
 
-Confirm that both the starter pack's documentation and your project build with 
+Confirm that both the Starter Pack's documentation and your project build with 
 no errors.
 
 .. important::
@@ -40,8 +40,8 @@ no errors.
 
 Update the configuration and build files
 ----------------------------------------
-New starter pack versions often change the default configuration files. You'll 
-need to merge your project files with the config files from the new starter pack.
+New Starter Pack versions often change the default configuration files. You'll 
+need to merge your project files with the config files from the new Starter Pack.
 The recommended approach is to copy the customizations in your project to the starter 
 pack's config files and then replace your project's config files with the starter 
 pack's. 
@@ -51,7 +51,7 @@ cannot be overly prescriptive.
 
 ``conf.py``
 ~~~~~~~~~~~
-Rename your ``conf.py`` file to avoid overwriting it, and copy the starter pack's 
+Rename your ``conf.py`` file to avoid overwriting it, and copy the Starter Pack's 
 version to the same location. Use a graphical diff tool such as `Kompare <https://apps.kde.org/kompare/>`_
 or `meld <https://meldmerge.org/>`_ to compare the old and new file and make the 
 following changes:
@@ -72,7 +72,7 @@ or include a new change, reach out to `Canonical's documentation team <https://m
 
 ``Makefile`` and ``.readthedocs.yaml``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Depending on the version of your project's starter pack, the new ``Makefile`` and ``.readthedocs.yaml``
+Depending on the version of your project's Starter Pack, the new ``Makefile`` and ``.readthedocs.yaml``
 files may have few or no changes. Apply the same approach you used for ``conf.py`` 
 to merge your customizations into the new files. 
 
@@ -85,13 +85,13 @@ In addition to the docs above, the ``/.sphinx`` directory is also likely to have
 changes in each update. These files are not intended to be modified by users. 
 
 Unless you intentionally customized files in this directory, you can simply delete 
-your project's ``/.sphinx`` directory and replace it with the starter pack's. If there 
+your project's ``/.sphinx`` directory and replace it with the Starter Pack's. If there 
 are modifications in your project's ``/.sphinx`` directory, it is recommended that 
 they transfer them out.
 
 Review the remaining files
 --------------------------
-Some files in the starter pack may be updated less frequently, but it's a good idea 
+Some files in the Starter Pack may be updated less frequently, but it's a good idea 
 to review them during each update and determine if there are relevant changes:
 
 -   Review ``requirements.txt``: If there are any updates, and your project's file 
@@ -148,7 +148,7 @@ specific files or files that have been replaced with newer versions:
 -   If you haven't done so already, delete the copies of ``conf.py``, ``Makefile``, and 
     ``/.readthedocs.yaml`` that were renamed and replaced. 
 -   If you did not strictly follow this guide for this or previous updates, it's 
-    possible that you have some starter pack-specific files in your project. 
+    possible that you have some Starter Pack-specific files in your project. 
     These files can be safely deleted: 
 
     -   ``.github/pull_request_template.md``

--- a/docs/how-to/update-starter-packs/new-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/new-starter-pack.rst
@@ -16,7 +16,7 @@ bugs. You can transfer these improvements to your project by following these ste
 
 This guide assumes your project has minimal customizations, and the repository 
 structure closely mirrors the starter pack's. Depending on your customizations, 
-you may need to take extra steps when upgrading. 
+you may need to take extra steps when updating. 
 
 .. note::
    If ``canonical-sphinx`` is not included under ``extensions`` in your ``conf.py``, 
@@ -46,7 +46,7 @@ The recommended approach is to copy the customizations in your project to the st
 pack's config files and then replace your project's config files with the starter 
 pack's. 
 
-The changes to be made vary between projects and upgrades. Therefore, this guide 
+The changes to be made vary between projects and updates. Therefore, this guide 
 cannot be overly prescriptive.
 
 ``conf.py``
@@ -82,7 +82,7 @@ in the new ones, you can just overwrite your existing files with the new ones.
 Update the ``.sphinx`` directory
 --------------------------------
 In addition to the docs above, the ``/.sphinx`` directory is also likely to have some
-changes in each upgrade. These files are not intended to be modified by users. 
+changes in each update. These files are not intended to be modified by users. 
 
 Unless you intentionally customized files in this directory, you can simply delete 
 your project's ``/.sphinx`` directory and replace it with the starter pack's. If there 
@@ -92,7 +92,7 @@ they transfer them out.
 Review the remaining files
 --------------------------
 Some files in the starter pack may be updated less frequently, but it's a good idea 
-to review them during each upgrade and determine if there are relevant changes:
+to review them during each update and determine if there are relevant changes:
 
 -   Review ``requirements.txt``: If there are any updates, and your project's file 
     has no repository-specific requirements, you can overwrite the existing file 
@@ -119,7 +119,7 @@ Try building the docs locally and check the terminal output for errors::
 
     make run
 
-To ensure the upgraded docs will pass CI checks when you make a pull request, run 
+To ensure the updated docs will pass CI checks when you make a pull request, run 
 the following commands and fix any errors reported:
 
 -   ``make spelling``
@@ -142,12 +142,12 @@ build files are not reused.
 
 Clean up 
 --------
-There may be files that need to be deleted after the upgrade such as starter-pack 
+There may be files that need to be deleted after the update such as starter-pack 
 specific files or files that have been replaced with newer versions: 
 
 -   If you haven't done so already, delete the copies of ``conf.py``, ``Makefile``, and 
     ``/.readthedocs.yaml`` that were renamed and replaced. 
--   If you did not strictly follow this guide for this or previous upgrades, it's 
+-   If you did not strictly follow this guide for this or previous updates, it's 
     possible that you have some starter pack-specific files in your project. 
     These files can be safely deleted: 
 


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----
This PR aims to introduce some small tweaks for the sake of consistency:

- replace `upgrade` with `update` in places where it looks like it makes sense
- adds meta descriptions to how-tos that are missing it
- adds introductory sentences to how-tos that are missing it
- use a simple "your project" in most cases to refer to user's starter pack-based project
- since we don't have a standard way of capitalizing SP, I preferred lower case capitalization except for instances where it's `Sphinx Documentation Starter Pack` 
- move URLs to `relatedlinks` where possible -- it's not possible for cross-references so I didn't touch those

See [DOCPR-2518](https://warthogs.atlassian.net/browse/DOCPR-2518) for more context

[DOCPR-2518]: https://warthogs.atlassian.net/browse/DOCPR-2518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ