### PR TITLE
Docs: Clarify first step of legacy starter pack migration

### DIFF
--- a/docs/how-to/update-starter-packs/legacy-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/legacy-starter-pack.rst
@@ -18,26 +18,20 @@ The extension-based documentation starter pack provides a set of features and co
 Update to the last pre-extension version
 ----------------------------------------
 
-To ensure a smooth migration, update your documentation project to use the last pre-extension version of the Sphinx Documentation Starter Pack.
+Update your documentation project to use the last pre-extension version of the Sphinx Documentation Starter Pack. Doing so will minimize the changes required during the migration by including the the latest features and configurations available in the pre-extension version.
 
-In your project repository, check out the last pre-extension release tag or branch. This step ensures that your project is using the latest features and configurations available in the pre-extension version, minimizing the changes required during the migration.
+In your project repository, check out the `pre-extension release tag <https://github.com/canonical/sphinx-docs-starter-pack/releases/tag/pre-extension>`_:
 
-To check out the `pre-extension branch <https://github.com/canonical/sphinx-docs-starter-pack/tree/pre-extension>`_
-
-..code block:: bash
-
-   git checkout pre-extension
-
-To check out the `pre-extension release tag <https://github.com/canonical/sphinx-docs-starter-pack/releases/tag/pre-extension>`_::
-
-..code block:: bash
+.. code-block:: bash
 
    git checkout tags/pre-extension
 
 .. admonition:: Repository in detached HEAD state
    :class: note
 
-   Checking out a tag leaves your repository in a `detached HEAD state <https://git-scm.com/docs/git-checkout#_detached_head>`_. Before proceeding, create a new branch to work from::
+   Checking out a tag leaves your repository in a `detached HEAD state <https://git-scm.com/docs/git-checkout#_detached_head>`_. Before proceeding, create a new branch:
+
+   .. code-block:: bash
 
       git checkout -b migrate-to-extension
 

--- a/docs/how-to/update-starter-packs/legacy-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/legacy-starter-pack.rst
@@ -18,12 +18,23 @@ The extension-based documentation starter pack provides a set of features and co
 Update to the last pre-extension version
 ----------------------------------------
 
-To ensure a smooth migration, update your documentation project to use the last pre-extension version of the Sphinx Documentation Starter Pack. This update ensures that your project is using the latest features and configurations available, minimising the changes required during the migration.
+To ensure a smooth migration, update your documentation project to use the last pre-extension version of the Sphinx Documentation Starter Pack.
 
-You can find the release tag and branch for this version in the following links:
+In your project repository, check out the last pre-extension release tag or branch. This step ensures that your project is using the latest features and configurations available in the pre-extension version, minimising the changes required during the migration.
 
-* `pre-extension branch <https://github.com/canonical/sphinx-docs-starter-pack/tree/pre-extension>`_
-* `pre-extension release tag <https://github.com/canonical/sphinx-docs-starter-pack/releases/tag/pre-extension>`_
+To check out the `pre-extension branch <https://github.com/canonical/sphinx-docs-starter-pack/tree/pre-extension>`_::
+
+   git checkout pre-extension
+
+To check out the `pre-extension release tag <https://github.com/canonical/sphinx-docs-starter-pack/releases/tag/pre-extension>`_::
+
+   git checkout tags/pre-extension
+
+.. note::
+
+   Checking out a tag leaves your repository in a `detached HEAD state <https://git-scm.com/docs/git-checkout#_detached_head>`_. Before proceeding, create a new branch to work from::
+
+      git checkout -b migrate-to-extension
 
 
 Set up a new project

--- a/docs/how-to/update-starter-packs/legacy-starter-pack.rst
+++ b/docs/how-to/update-starter-packs/legacy-starter-pack.rst
@@ -20,17 +20,22 @@ Update to the last pre-extension version
 
 To ensure a smooth migration, update your documentation project to use the last pre-extension version of the Sphinx Documentation Starter Pack.
 
-In your project repository, check out the last pre-extension release tag or branch. This step ensures that your project is using the latest features and configurations available in the pre-extension version, minimising the changes required during the migration.
+In your project repository, check out the last pre-extension release tag or branch. This step ensures that your project is using the latest features and configurations available in the pre-extension version, minimizing the changes required during the migration.
 
-To check out the `pre-extension branch <https://github.com/canonical/sphinx-docs-starter-pack/tree/pre-extension>`_::
+To check out the `pre-extension branch <https://github.com/canonical/sphinx-docs-starter-pack/tree/pre-extension>`_
+
+..code block:: bash
 
    git checkout pre-extension
 
 To check out the `pre-extension release tag <https://github.com/canonical/sphinx-docs-starter-pack/releases/tag/pre-extension>`_::
 
+..code block:: bash
+
    git checkout tags/pre-extension
 
-.. note::
+.. admonition:: Repository in detached HEAD state
+   :class: note
 
    Checking out a tag leaves your repository in a `detached HEAD state <https://git-scm.com/docs/git-checkout#_detached_head>`_. Before proceeding, create a new branch to work from::
 


### PR DESCRIPTION
The first step while migrating from a legacy starter pack asks users to update to the latest pre-extension version.
New users can be confused and not make the connection to perform a git checkout to fetch the latest pre-extension files.
This PR adds clarification around what steps the user needs to do to checkout the latest pre-extension tag or branch.

- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----
