### PR TITLE
Change 'documentation starter pack' to 'sphinx starter pack'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ import yaml
 #
 # TODO: Update with the official name of your project or product
 
-project = "Documentation starter pack"
+project = "Sphinx starter pack"
 author = "Canonical Ltd."
 
 # The year in the copyright statement defaults to the current year, so

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Documentation starter pack
-==========================
+Sphinx starter pack documentation
+=================================
 
 The documentation starter pack helps you to quickly set up, build, and publish
 documentation with Sphinx.


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----
Addresses issue https://github.com/canonical/sphinx-stack-docs/issues/9

I've changed the project name from "Documentation starter pack" to "Sphinx starter pack". This way we avoid the repetition of "Documentation starter pack documentation".