### PR TITLE
fix: indentation in bridging how-to

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -74,7 +74,7 @@ sequenceDiagram
 Numpy
 openapi
 docstrings?
-Makefile
+Makefiles?
 rediraffe
 retrigger(ing)?
 Diátaxis

--- a/docs/how-to/optional-customisation/bridge-project-and-docs-builds.rst
+++ b/docs/how-to/optional-customisation/bridge-project-and-docs-builds.rst
@@ -266,14 +266,17 @@ In the example project, the main build calls the targets like this:
 
 .. admonition:: Variables and Makefiles
 
-   When calling another Makefile with ``$(MAKE) -C``, also known as a sub-Make call, variables with default values in the child Makefile won't be overridden. To override them, you must set them explicitly with `export` or as as command-line arguments.
+    When calling another Makefile with ``$(MAKE) -C``, also known as a sub-Make call,
+    variables with default values in the child Makefile won't be overridden. To override
+    them, you must set them explicitly with `export` or as as command-line arguments.
 
-   For example, within the main build, if you need to customize ``SPHINX_AUTOBUILD_OPTS``, pass it to the docs build like this:
+    For example, within the main build, if you need to customize
+    ``SPHINX_AUTOBUILD_OPTS``, pass it to the docs build like this:
 
     .. code-block:: make
         :caption: Makefile
 
-        $(MAKE) -C docs run SPHINX_AUTOBUILD_OPTS="$(SPHINX_AUTOBUILD_OPTS)"
+    		$(MAKE) -C docs run SPHINX_AUTOBUILD_OPTS="$(SPHINX_AUTOBUILD_OPTS)"
 
 .. _how-to-bridge-project-builds-adjust-rtd-build:
 


### PR DESCRIPTION
The `make` lexer for code blocks expects tab characters.


---
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?
