### PR TITLE
chore: add a-velasco to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # Development reviewers
 # Adjust this once we establish a Sphinx development team.
-* @akcano @dwilding @medubelko @minaelee @rkratky @SecondSkoll @tang-mm
+* @a-velasco @akcano @dwilding @medubelko @minaelee @rkratky @SecondSkoll @tang-mm
 
 # Changes to CODEOWNERS must be reviewed by admins
 /.github/CODEOWNERS @SecondSkoll


### PR DESCRIPTION
@a-velasco is an ongoing epic driver and maintainer of the code, and should have the permission to provide a required approval for the developments under her supervision.