### PR TITLE
Update Sphinx Stack project setup link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming
 
+* Update link to documenation in README
 * Add an `AUTOBUILD_EXTRA_OPTS` variable to extend sphinx-autobuild options for `make run`
 * Add default support for the sphinx-llm extension
 * Pin dependencies to major versions
@@ -12,6 +13,7 @@
 
 ### Changed
 
+* `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
 * `docs/conf.py`  [#562](https://github.com/canonical/sphinx-docs-starter-pack/pull/562), [#576](https://github.com/canonical/sphinx-docs-starter-pack/pull/576), [#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590), [#595](https://github.com/canonical/sphinx-docs-starter-pack/pull/595), [#598](https://github.com/canonical/sphinx-docs-starter-pack/pull/598)
 * `docs/Makefile` [#575](https://github.com/canonical/sphinx-docs-starter-pack/pull/575), [#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590)
 * `docs/requirements.txt` [#590]([#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590))

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ documentation, and serve it to http://127.0.0.1:8000.
 
 To learn more about how to install and configure the Sphinx Stack for your own project,
 see the [Set up a new
-project](https://canonical-sphinx-stack.readthedocs-hosted.com/stable/tutorial/set-up/)
+project](https://canonical-sphinx-stack.readthedocs-hosted.com/latest/set-up-a-new-project/)
 guide in the official documentation.
 
 ## Requirements and limitations


### PR DESCRIPTION
Drive by fix - the current link gives a 404.

- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----
