### PR TITLE
fix: filter out build dir from Vale checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# sphinx-docs-starter-pack changelog
+# sphinx-stack changelog
 
 ## Upcoming
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Upcoming
 
+* Prevent Vale from processing Markdown files in the build directory
 * Update link to documenation in README
+
+### Changed
+
+* `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605)
+* `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
+
+## 2.0
+
 * Add an `AUTOBUILD_EXTRA_OPTS` variable to extend sphinx-autobuild options for `make run`
 * Add default support for the sphinx-llm extension
 * Pin dependencies to major versions
@@ -13,7 +22,6 @@
 
 ### Changed
 
-* `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
 * `docs/conf.py`  [#562](https://github.com/canonical/sphinx-docs-starter-pack/pull/562), [#576](https://github.com/canonical/sphinx-docs-starter-pack/pull/576), [#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590), [#595](https://github.com/canonical/sphinx-docs-starter-pack/pull/595), [#598](https://github.com/canonical/sphinx-docs-starter-pack/pull/598)
 * `docs/Makefile` [#575](https://github.com/canonical/sphinx-docs-starter-pack/pull/575), [#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590)
 * `docs/requirements.txt` [#590]([#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590))

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ VALE_DIR         ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
 VALE_CONFIG      ?= $(DEV_DIR)/vale.ini
 PA11Y_CMD        ?= $(DEV_DIR)/node_modules/pa11y/bin/pa11y.js --config $(DEV_DIR)/pa11y.json
 CONFIRM_SUDO     ?= N
-CHECK_PATH       ?= $(filter-out $(DOCS_VENVDIR),$(wildcard *))
+CHECK_PATH       ?= $(filter-out $(DOCS_VENVDIR) $(DOCS_BUILDDIR),$(wildcard *))
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
This PR fixes the following bug:

1. Clone a repo with documentation, e.g., https://github.com/canonical/sphinx-stack-docs
2. Run `make -C docs html`
3. Run `make -C docs spelling`

The spelling check fails on the LLM .md files in `_build` because those .md files don't have the rich formatting that Vale would normally ignore.

---

- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] ~Have you updated the documentation for this change?~