### PR TITLE
ci: add read permissions to the CLA workflow

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   cla-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 * `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605)
 * `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
-* `.github/workflows/cla-check.yml` [606](https://github.com/canonical/sphinx-stack/pull/606)
+* `.github/workflows/cla-check.yml` [#606](https://github.com/canonical/sphinx-stack/pull/606)
 
 ## 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605)
 * `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
+* `.github/workflows/cla-check.yml` [606](https://github.com/canonical/sphinx-stack/pull/606)
 
 ## 2.0
 


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
There have been some recent CLA failures (in at least two doc sets), with an error message that says  ` Error: Resource not accessible by integration`. This seems to have been caused by a lack of explicit read permissions for the CLA workflow as required by a recent change in policy to improve security. Adding the permissions resolves the issue. 

No examples are linked here because the doc sets affected so far are internal, but it's possible this may extend to other docs as well due to the new policy. It's still unclear why the scope of the failures has been limited so far.