### PR TITLE
fix: update file paths missed in 2.0

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ SPHINX_OPTS      ?= -c . -d $(DEV_DIR)/.doctrees -j auto
 SPHINX_BUILD     ?= $(DOCS_VENVDIR)/bin/sphinx-build
 SPHINX_HOST      ?= 127.0.0.1
 SPHINX_PORT      ?= 8000
-SPHINX_AUTOBUILD_OPTS ?= -D=llms_txt_enabled=0
+SPHINX_AUTOBUILD_OPTS ?= -D llms_txt_enabled=0
 DOCS_VENVDIR     ?= .venv
 DOCS_VENV        ?= $(DOCS_VENVDIR)/bin/activate
 DOCS_SOURCEDIR   ?= .

--- a/docs/_dev/update_sp.py
+++ b/docs/_dev/update_sp.py
@@ -5,7 +5,7 @@
 # Requires some manual intervention, but makes identifying updates and differences easier.
 #
 # For debugging, please run this script with DEBUGGING=1
-# e.g. user@device:~/git/Canonical/sphinx-stack/docs$ DEBUGGING=1 python .sphinx/update_sp.py
+# e.g. user@device:~/git/Canonical/sphinx-stack/docs$ DEBUGGING=1 python _dev/update_sp.py
 
 
 import glob

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ ogp_image = "https://assets.ubuntu.com/v1/cc828679-docs_illustration.svg"
 
 # Product favicon; shown in bookmarks, browser tabs, etc.
 # TODO: To customise the favicon, uncomment and update the next line.
-# html_favicon = ".sphinx/_static/favicon.png"
+# html_favicon = "_static/favicon.png"
 
 # Dictionary of values to pass into the Sphinx context for all pages:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
According to the sphinx-llm docs, the second `=`  in `SPHINX_AUTOBUILD_OPTS ?= -D=llms_txt_enabled=0` is supposed to be a space.
Ref: https://pypi.org/project/sphinx-llm/
