### PR TITLE
fix: don't run checks on `_dev` dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Upcoming
 
-* Prevent Vale from processing Markdown files in the build directory
-* Update link to documenation in README
+* Exclude utility directories from builds and checks
+* Update link to documentation in README
 
 ### Changed
 
+* `docs/conf.py` [#610](https://github.com/canonical/sphinx-stack/pull/610)
 * `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605), [#610](https://github.com/canonical/sphinx-stack/pull/610)
 * `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
 * `.github/workflows/cla-check.yml` [#606](https://github.com/canonical/sphinx-stack/pull/606)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Changed
 
-* `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605)
+* `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605), [#610](https://github.com/canonical/sphinx-stack/pull/610)
 * `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
 * `.github/workflows/cla-check.yml` [#606](https://github.com/canonical/sphinx-stack/pull/606)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ VALE_DIR         ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
 VALE_CONFIG      ?= $(DEV_DIR)/vale.ini
 PA11Y_CMD        ?= $(DEV_DIR)/node_modules/pa11y/bin/pa11y.js --config $(DEV_DIR)/pa11y.json
 CONFIRM_SUDO     ?= N
-CHECK_PATH       ?= $(filter-out $(DOCS_VENVDIR) $(DOCS_BUILDDIR),$(wildcard *))
+CHECK_PATH       ?= $(filter-out $(DOCS_VENVDIR) $(DOCS_BUILDDIR) $(DEV_DIR),$(wildcard *))
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,6 +243,7 @@ extensions = [
 exclude_patterns = [
     "doc-cheat-sheet*",
     ".venv*",
+    "_dev",
 ]
 
 # Adds custom CSS files, located remotely or in 'html_static_path'.


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
~~Have you updated the documentation for this change?~~

-----

If you run additional checks or builds after running pa11y, any reST or MD files in `_dev/node_modules/` directory are read as source and then . With this change, the checks will ignore the `_dev` directory.

(If you're curious, this regression was caused when we renamed `.sphinx` to `_dev`, because `canonical-sphinx` secretly adds `.sphinx` to `exclude_patterns`. This is why we shouldn't obfuscate configuration!)