### PR TITLE
chore: Add build folder to the gitignore list.

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -15,6 +15,7 @@ _dev/vale.ini
 
 # Build outputs
 _build
+_dev
 
 # Node.js
 package*.json


### PR DESCRIPTION
- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
The `_dev` folder is a build folder and changes to it should not be committed.