### PR TITLE
fix: traceback when exiting `make run` with Ctrl+C

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -79,7 +79,7 @@ pymarkdownlnt-install: install
 install: $(DOCS_VENVDIR)
 
 run: install
-	. $(DOCS_VENV); $(DOCS_VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS) $(SPHINX_AUTOBUILD_OPTS)
+	. $(DOCS_VENV); $(DOCS_VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS) $(SPHINX_AUTOBUILD_OPTS) & PID=$$!; trap "kill -9 $$PID 2>/dev/null; exit 0" INT; wait $$PID
 
 # Does not depend on $(DOCS_BUILDDIR) to rebuild properly at every run.
 html: install


### PR DESCRIPTION
Fixes #620

`make run` uses `sphinx-autobuild`, which watches files with `watchfiles` (Rust) and serves docs with Starlette/uvicorn. On Ctrl+C, the interrupt propagates into the async stack, the Rust watcher panics during cleanup, and Starlette prints a misleading traceback:

```text
_rust_notify.WatchfilesRustInternalError: Error creating recommended watcher: Too many open files (os error 24)
ERROR:    Application shutdown failed. Exiting.
```

## Fix

Run `sphinx-autobuild` in the background and install a `SIGINT` trap that kills it with `SIGKILL` before the interrupt reaches the Python process. `SIGKILL` is unblockable, so the process dies instantly — no async shutdown, no traceback.

Real errors (port in use, build failure) still propagate normally: the trap only fires on `SIGINT`, so `wait $PID` returns the real exit code and `make` reports it as before.