### PR TITLE
Tell sphinx-llm to not run in parallel to fix RTD errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,6 +157,8 @@ rediraffe_redirects = "redirects.txt"
 # Strips '/index.html' from destination URLs when building with 'dirhtml'
 rediraffe_dir_only = True
 
+# Run sphinx-llm markdown generation sequentially to prevent race conditions
+llms_txt_build_parallel = False
 
 ############################
 # sphinx-llm configuration #


### PR DESCRIPTION
sphinx-llm by default creates a parallel process that touches build files while the main process (or other extensions, like sphinx-tags) could still be using them. This should fix that.

- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
